### PR TITLE
dev-requirements: remove colorama from requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,8 +14,6 @@ nox
 # cli
 memory-profiler
 networkx
-# logs + 🌈 = 😎
-colorama
 # releases
 bump2version
 # optional


### PR DESCRIPTION
Issue I was faced when pip installing requirements-dev.txt:
```
ERROR: Double requirement given: colorama (from -r requirements-dev.txt (line 18)) (already in colorama==0.4.4 (from -r requirements.txt (line 33)), name='colorama')
```

Colorama actually was in both requirements.txt and requirements-dev.txt files.
Removed it from the latter.

Thanks for reviewing