### PR TITLE
Allow disabling validation

### DIFF
--- a/modelkit/core/settings.py
+++ b/modelkit/core/settings.py
@@ -29,7 +29,7 @@ class LibrarySettings(pydantic.BaseSettings):
     override_storage_prefix: Optional[str] = pydantic.Field(
         None, env="OVERRIDE_STORAGE_PREFIX"
     )
-
+    enable_validation: bool = pydantic.Field(True, env="ENABLE_VALIDATION")
     tf_serving: TFServingSettings = pydantic.Field(
         default_factory=lambda: TFServingSettings()
     )

--- a/modelkit/utils/pydantic.py
+++ b/modelkit/utils/pydantic.py
@@ -1,0 +1,32 @@
+def construct_recursive(cls, _fields_set=None, **values):
+    # https://github.com/samuelcolvin/pydantic/issues/1168
+    m = cls.__new__(cls)
+    fields_values = {}
+
+    for name, field in cls.__fields__.items():
+        key = field.alias
+        if key in values:  # this check is necessary or Optional fields will crash
+            try:
+                # if issubclass(field.type_, BaseModel):  # this is cleaner but slower
+                if field.shape == 2:
+                    fields_values[name] = [
+                        construct_recursive(field.type_, **e) for e in values[key]
+                    ]
+                else:
+                    fields_values[name] = construct_recursive(
+                        field.outer_type_, **values[key]
+                    )
+            except (AttributeError, TypeError):
+                if values[key] is None and not field.required:
+                    fields_values[name] = field.get_default()
+                else:
+                    fields_values[name] = values[key]
+        elif not field.required:
+            fields_values[name] = field.get_default()
+
+    object.__setattr__(m, "__dict__", fields_values)
+    if _fields_set is None:
+        _fields_set = set(values.keys())
+    object.__setattr__(m, "__fields_set__", _fields_set)
+    m._init_private_attributes()
+    return m

--- a/tests/assets/test_settings.py
+++ b/tests/assets/test_settings.py
@@ -12,6 +12,7 @@ from modelkit.assets.settings import (
     DriverSettings,
     RemoteAssetsStoreSettings,
 )
+from modelkit.core.settings import LibrarySettings
 
 test_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -167,3 +168,12 @@ def test_assetsmanager_minimal_prefix(monkeypatch, working_dir):
     assert settings.remote_store.driver.settings.bucket == "some-bucket"
     assert settings.remote_store.storage_prefix == "a-prefix"
     assert settings.assets_dir == Path(working_dir)
+
+
+def test_assetsmanager_no_validation(monkeypatch, working_dir):
+    monkeypatch.setenv("WORKING_DIR", working_dir)
+    settings = LibrarySettings()
+    assert settings.enable_validation
+    monkeypatch.setenv("ENABLE_VALIDATION", "False")
+    settings = LibrarySettings()
+    assert not settings.enable_validation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def clean_env():
         "LAZY_LOADING",
         "ASSETSMANAGER_PREFIX",
         "ASSETSMANAGER_TIMEOUT_S",
+        "ENABLE_VALIDATION",
     ]:
         os.environ.pop(env_var, None)
 

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -63,4 +63,11 @@ def test_describe():
         # modelkit.utils.memory cannot track memory increment
         # and write it
         r = ReferenceText(os.path.join(TEST_DIR, "testdata"))
-        r.assert_equal("library_describe.txt", capture.get())
+        captured = capture.get()
+        EXCLUDED = ["load time", "load memory"]
+        captured = "\n".join(
+            line
+            for line in captured.split("\n")
+            if not any(x in line for x in EXCLUDED)
+        )
+        r.assert_equal("library_describe.txt", captured)

--- a/tests/testdata/library_describe.txt
+++ b/tests/testdata/library_describe.txt
@@ -33,8 +33,6 @@ Models
 │   │                                                                           
 │   │           With **a lot** of documentation                                 
 │   ├── signature: ItemModel -> ItemModel                                       
-│   ├── load time: 0 microseconds                                               
-│   ├── load memory: 0 Bytes                                                    
 │   └── batch size: 64                                                          
 └── some_model_a : SomeSimpleValidatedModelA = SomeSimpleValidatedModelA        
     instance                                                                    
@@ -43,6 +41,4 @@ Models
     │                                                                           
     │           that also has plenty more text                                  
     ├── signature: str -> str                                                   
-    ├── load time: 0 microseconds                                               
-    ├── load memory: 0 Bytes                                                    
     └── batch size: 64                                                          

--- a/tests/testdata/library_describe.txt
+++ b/tests/testdata/library_describe.txt
@@ -2,6 +2,7 @@ Settings
 ├── lazy_loading : bool = False                                                 
 ├── async_mode : bool = None                                                    
 ├── override_storage_prefix : str = None                                        
+├── enable_validation : bool = True                                             
 ├── tf_serving : TFServingSettings                                              
 │   ├── enable : bool = False                                                   
 │   ├── mode : str = 'rest'                                                     


### PR DESCRIPTION
In this PR I suggest adding the possibility to disable the validation of `Model` inputs and outputs. The reason for that is that it can be faster, and does not necessarily make sense in production once the model is completely tested.

It raises several issues. Typically, when a model has a `pydantic.BaseModel` input, attributes are referred to with natural naming, although the item is called with a dictionary. We want to be able to switch between the two modes without having to rewrite the `_predict_*` code.

This is achievable by using pydantic's ability to `construct` [models without validation]( https://pydantic-docs.helpmanual.io/usage/models/#creating-models-without-validation). 

However, this method cannot properly construct nested models: only the outer most model is constructed, and the rest is kept as is. I manage to get around this by implementing a custom construct function following on [this issue](https://github.com/samuelcolvin/pydantic/issues/1168).

Another issue is the way that `Union[Item, List[Item]]` is dealt with, which forces me to rewrite a little bit of this code in the Model logic itself. 

In the end, it looks OK. Turning the validation off (with `ENABLE_VALIDATION=False`) seems to yield a 30% speedup. Obviously this will depend a lot on the model to validate.

Happy to know what you guys think.