### PR TITLE
Separate predict logics

### DIFF
--- a/docs/library/developing_modelkit.md
+++ b/docs/library/developing_modelkit.md
@@ -290,8 +290,8 @@ batches of inputs at once. In this case, one can override `_predict_batch` inste
 ```python
 
 class IdentityBatched(Model)
-    async def _predict(self, items):
-        return items
+    async def _predict(self, item):
+        return item
     
 m_batched = IdentityBatched()
 ```
@@ -324,8 +324,8 @@ class IdentityBatched(Model):
             }
         }
     }
-    async def _predict(self, items):
-        return items
+    async def _predict(self, item):
+        return item
 ```
 
 ## `Asset` class

--- a/docs/library/developing_modelkit.md
+++ b/docs/library/developing_modelkit.md
@@ -15,7 +15,7 @@ Some quick `Model` facts:
 
 `modelkit` models are subclasses of the `modelkit.core.model.Model` class.
 
-The prediction logic is implemented in an asynchronous `_predict_one` method that takes a single argument `item`. This represents a single item, which is usually a json serializable dict (with maybe numpy arrays). In fact, Models implement `_predict_one` or `_predict_multiple` (both async) methods, and `Model` appropriately chooses between them and batches.
+The prediction logic is implemented in an asynchronous `_predict` method that takes a single argument `item`. This represents a single item, which is usually a json serializable dict (with maybe numpy arrays). In fact, Models implement `_predict` or `_predict_batch` (both async) methods, and `Model` appropriately chooses between them and batches.
 
 The asset loading logic is implemented in a `_load` method that is run after the `Model` is instantiated, and can load the asset specified in the `Model`'s configuration. For more on this see Lazy Mode.
 
@@ -27,7 +27,7 @@ This simple model class will always return `"something"`:
 from modelkit.core.model import Model
 
 class SimpleModel(Model):
-    async def _predict_one(self, item) -> str:
+    async def _predict(self, item) -> str:
         return "something"
 ```
 
@@ -51,12 +51,12 @@ class SimpleModel(Model):
     CONFIGURATIONS = {
         "simple": {}
     }
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return "something"
 ```
 
 !!! important
-    You have to `async def` when implementing `_predict_one` and `_predict_multiple`, even if the function is synchronous.
+    You have to `async def` when implementing `_predict` and `_predict_batch`, even if the function is synchronous.
 
 Right now, we have only given it a name `"simple"` which makes the model available to other models via the `ModelLibrary`.
 
@@ -86,7 +86,7 @@ class SimpleModel(Model):
         "simple": {"model_settings": {"value" : "something"}},
         "simple2": {"model_settings": {"value" : "something2"}}
     }
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return self.model_settings["value"]
 ```
 
@@ -138,7 +138,7 @@ class ModelWithAsset(Model):
         with bz2.BZ2File(self.asset_path, "rb") as f:
             self.data_structure = pickle.load(f) # loads {"response": "YOLO les simpsons"}
 
-    async def _predict_one(self, item: Dict[str, str], **kwargs) -> float:
+    async def _predict(self, item: Dict[str, str], **kwargs) -> float:
         return self.data_structure["response"] # returns "YOLO les simpsons"
 ```
 
@@ -168,7 +168,7 @@ class SomeModel(Model):
 The `ModelLibrary` ensures that whenever `_load` or the `_predict_*` function are called, these models are loaded and present in the `model_dependencies` dictionary:
 
 ```python
-async def _predict_one(self, item):
+async def _predict(self, item):
     cleaned = self.models_dependencies["sentence_piece_cleaner"](item["text"])
     ...
 
@@ -207,7 +207,7 @@ In this case, the instantiated `SomeModel.model_dependencies["cleaner"]` will po
 And a set of attributes always present:
 
 - `model_classname` the name of the `Model`'s subclass
-- `batch_size` the batch size for the model: if `_predict_multiple` is implemented it will always get batches of this size (defaults to 64)
+- `batch_size` the batch size for the model: if `_predict_batch` is implemented it will always get batches of this size (defaults to 64)
 
 ## Model typing
 
@@ -218,7 +218,7 @@ Types are specified when instantiating the `Model` class:
 ```python
 # This model takes `str` items and always returns `int` values
 class SomeTypedModel(Model[str, int]):
-    def _predict_one(self, item):
+    def _predict(self, item):
         return len(item)
 ```
 
@@ -256,12 +256,12 @@ class ReturnModel(pydantic.BaseModel):
     x: int
 
 class SomeValidatedModel(Model[ItemModel, ReturnModel]):
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         # item is guaranteed to be an instance of `ItemModel` even if we feed a dictionary item
         return {"x": item.x}
 
 m = SomeValidatedModel()
-# although we return a dict from the _predict_one method, return value
+# although we return a dict from the _predict method, return value
 # is turned into a `ReturnModel` instance.
 y : ReturnModel = m({"x": 1})
 # which also works with lists of items
@@ -275,7 +275,7 @@ y : List[ReturnModel] = m([{"x": 1}, {"x": 2}])
 ```python
 
 class Identity(Model)
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
     
 m = Identity()
@@ -284,12 +284,12 @@ m([{}, {"hello": "world"}]) == [{}, {"hello": "world"}]
 ```
 
 It is sometimes interesting to implement batched or vectorized logic, to treat
-batches of inputs at once. In this case, one can override `_predict_multiple` instead of `_predict_one`:
+batches of inputs at once. In this case, one can override `_predict_batch` instead of `_predict`:
 
 ```python
 
 class IdentityBatched(Model)
-    async def _predict_one(self, items):
+    async def _predict(self, items):
         return items
     
 m_batched = IdentityBatched()
@@ -322,7 +322,7 @@ class IdentityBatched(Model):
             }
         }
     }
-    async def _predict_one(self, items):
+    async def _predict(self, items):
         return items
 ```
 

--- a/docs/library/developing_modelkit.md
+++ b/docs/library/developing_modelkit.md
@@ -280,7 +280,8 @@ class Identity(Model)
     
 m = Identity()
 m({}) # == {}
-m([{}, {"hello": "world"}]) == [{}, {"hello": "world"}]
+# or
+m.predict_batch([{}, {"hello": "world"}]) == [{}, {"hello": "world"}]
 ```
 
 It is sometimes interesting to implement batched or vectorized logic, to treat
@@ -299,16 +300,17 @@ Requesting model predictions will lead to the exact same result:
 
 ```python
 m_batched({}) # == {}
-m_batched([{}, {"hello": "world"}]) == [{}, {"hello": "world"}]
+m_batched.predict_batch([{}, {"hello": "world"}]) == [{}, {"hello": "world"}]
 ```
 
 ### Batch size
 
 When `_predict_muliple` is overridden, the `Model` will call it with lists of items. 
-The length of the list can be controled by the `batch_size`, either at call time:
+
+The length of the list is fixed and controled by the `batch_size` parameter either at call time:
 
 ```python
-m_batched([{}, {"hello": "world"}], batch_size=2) 
+m_batched.predict_batch([{}, {"hello": "world"}], batch_size=2) 
 ```
 
 or set in the model configuration

--- a/docs/library/overview.md
+++ b/docs/library/overview.md
@@ -18,7 +18,7 @@ The normal way to use `modelkit` models is by instantiating a `ModelLibrary` wit
 from modelkit import ModelLibrary, Model
 
 class MyModel(Model):
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
 
 

--- a/docs/library/special/distant.md
+++ b/docs/library/special/distant.md
@@ -63,10 +63,10 @@ tensors predicted by the TF model:
 -   `output_tensor_shapes` and `output_tensor_dtypes` a dict of shapes and dtypes of these
     tensors.
 
-Typically, inside a `_predict_multiple`, one would do something like:
+Typically, inside a `_predict_batch`, one would do something like:
 
 ```python
-async def _predict_multiple(self, items):
+async def _predict_batch(self, items):
     data = await self._tensorflow_predict(
             {
                 key: np.stack([item[key] for item in items], axis=0)
@@ -85,7 +85,7 @@ async def _predict_multiple(self, items):
 
 !!! important
     Be careful that `_tensorflow_predict` returns a dict of `np.ndarray` of shape `(len(items),?)`
-    when `_predict_multiple` expects a list of `len(items)` dicts of `np.ndarray`.
+    when `_predict_batch` expects a list of `len(items)` dicts of `np.ndarray`.
 
 ## Other methods to re-implement
 
@@ -105,7 +105,7 @@ In this case we use the following pattern, wherein we leverage the method
 `TensorflowModel._rebuild_predictions_with_mask`:
 
 ```python
-async def _predict_multiple(
+async def _predict_batch(
     self, items: List[Dict[str, str]], **kwargs
 ) -> List[Tuple[np.ndarray, List[str]]]:
     treated_items = self.treat(items)

--- a/docs/library/special/tensorflow.md
+++ b/docs/library/special/tensorflow.md
@@ -16,10 +16,10 @@ At initialization time, a `TensorflowModel` has to be provided with definitions 
 - `output_tensor_mapping` a dict of arbitrary `key`s to tensor names describing the outputs.
 - `output_tensor_shapes` and `output_tensor_dtypes` a dict of shapes and dtypes of these tensors.
 
-Typically, inside a `_predict_multiple`, one would do something like:
+Typically, inside a `_predict_batch`, one would do something like:
 
 ```python
-async def _predict_multiple(self, items):
+async def _predict_batch(self, items):
     data = await self._tensorflow_predict(
             {
                 key: np.stack([item[key] for item in items], axis=0)
@@ -37,7 +37,7 @@ async def _predict_multiple(self, items):
 ```
 
 !!! important
-    Be careful that `_tensorflow_predict` returns a dict of `np.ndarray` of shape `(len(items),?)` when `_predict_multiple` expects a list of `len(items)` dicts of `np.ndarray`.
+    Be careful that `_tensorflow_predict` returns a dict of `np.ndarray` of shape `(len(items),?)` when `_predict_batch` expects a list of `len(items)` dicts of `np.ndarray`.
 
 ## Other convenience methods
 
@@ -54,7 +54,7 @@ Oftentimes we manipulate the item before feeding it to TF, e.g. doing text clean
 In this case we use the following pattern, wherein we leverage the method `TensorflowModel._rebuild_predictions_with_mask`:
 
 ```python
-async def _predict_multiple(
+async def _predict_batch(
     self, items: List[Dict[str, str]], **kwargs
 ) -> List[Tuple[np.ndarray, List[str]]]:
     treated_items = self.treat(items)

--- a/docs/library/testing.md
+++ b/docs/library/testing.md
@@ -38,7 +38,7 @@ class TestableModel(Model[ModelItemType, ModelItemType]):
         ]
     }
 
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
 
 ```

--- a/docs/library/using_models.md
+++ b/docs/library/using_models.md
@@ -9,7 +9,7 @@ The normal way to use `modelkit` models is by instantiating a `ModelLibrary` wit
 from modelkit import ModelLibrary, Model
 
 class MyModel(Model):
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
 
 
@@ -60,11 +60,11 @@ prediction = model(item)
 prediction = await model_async(item)
 ```
 
-If `predict` (or `predict_async`) sees a list, it will call `_predict_multiple` and
+If `predict` (or `predict_async`) sees a list, it will call `_predict_batch` and
 return a list of processed items (possibly leveraging batching/vectorization
 for performance).
 
-If `predict` sees something else it will try to call `_predict_one` on it and return the
+If `predict` sees something else it will try to call `_predict` on it and return the
 response for a single item.
 # CLIs
 

--- a/docs/library/using_models.md
+++ b/docs/library/using_models.md
@@ -50,22 +50,25 @@ model = library.get("my_favorite_model")
 
     If you have set the `MODELKIT_DEFAULT_PACKAGE` environment variable, you can also skip the `models=...` part.
 
-Predictions can be obtained either for a single item (usually a dict), or a _list of items_
-via the same predict method:
+Predictions can be obtained by calling the object:
 
 ```python
 # This runs the Model method
-prediction = model(item)
+prediction = model(item) # or model.predict(item)
 # or
-prediction = await model_async(item)
+prediction = await model.predict_async(item)
 ```
 
-If `predict` (or `predict_async`) sees a list, it will call `_predict_batch` and
-return a list of processed items (possibly leveraging batching/vectorization
-for performance).
+Predictions for list of items can be obtained by using `predict_batch`:
 
-If `predict` sees something else it will try to call `_predict` on it and return the
-response for a single item.
+```python
+prediction = model.predict_batch(items)
+# or
+prediction = await model.predict_batch_async(item)
+```
+
+Which allows the user to leverage vectorized code by implementing `_predict_batch` instead of `_predict`.
+
 # CLIs
 
 Also see the CLIs documentation [here](../cli.md)

--- a/docs/library/using_models.md
+++ b/docs/library/using_models.md
@@ -62,9 +62,9 @@ prediction = await model.predict_async(item)
 Predictions for list of items can be obtained by using `predict_batch`:
 
 ```python
-prediction = model.predict_batch(items)
+predictions = model.predict_batch(items)
 # or
-prediction = await model.predict_batch_async(item)
+predictions = await model.predict_batch_async(items)
 ```
 
 Which allows the user to leverage vectorized code by implementing `_predict_batch` instead of `_predict`.

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -100,7 +100,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
                 self.add_api_route(
                     path,
                     self._make_model_endpoint_fn(
-                        model_name, m._item_type if hasattr(m, "_item_type") else None
+                        model_name, m.item_type if hasattr(m, "item_type") else None
                     ),
                     methods=["POST"],
                     description=description,

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -223,6 +223,15 @@ class Model(Asset, Generic[ItemType, ReturnType]):
         batch_size: int = None,
         **kwargs,
     ):
+        return self.predict(items, callback=callback, batch_size=batch_size, **kwargs)
+
+    def predict(
+        self,
+        items,
+        callback: Callable = None,
+        batch_size: int = None,
+        **kwargs,
+    ):
         return _run_secretly_sync_async_fn(
             self.predict_async, items, callback, batch_size, **kwargs
         )

--- a/modelkit/core/models/distant_model.py
+++ b/modelkit/core/models/distant_model.py
@@ -60,7 +60,7 @@ class DistantHTTPModel(Model[ItemType, ReturnType]):
         pass
 
     @retry(**SERVICE_MODEL_RETRY_POLICY)
-    async def _predict_one_async(self, item):
+    async def _predict_async(self, item):
         if self.aiohttp_session is None:
             # aiohttp wants us to initialize the session in an event loop
             self.aiohttp_session = aiohttp.ClientSession()
@@ -75,7 +75,7 @@ class DistantHTTPModel(Model[ItemType, ReturnType]):
             return await response.json()
 
     @retry(**SERVICE_MODEL_RETRY_POLICY)
-    def _predict_one_sync(self, item):
+    def _predict_sync(self, item):
         if not self.requests_session:
             self.requests_session = requests.Session()
         response = self.requests_session.post(
@@ -88,13 +88,13 @@ class DistantHTTPModel(Model[ItemType, ReturnType]):
             )
         return response.json()
 
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         if self._async_mode is None:
             try:
                 asyncio.get_event_loop()
-                return await self._predict_one_async(item)
+                return await self._predict_async(item)
             except RuntimeError:
-                return self._predict_one_sync(item)
+                return self._predict_sync(item)
         if self._async_mode:
-            return await self._predict_one_async(item)
-        return self._predict_one_sync(item)
+            return await self._predict_async(item)
+        return self._predict_sync(item)

--- a/modelkit/core/models/tensorflow_model.py
+++ b/modelkit/core/models/tensorflow_model.py
@@ -85,8 +85,8 @@ class TensorflowModel(Model[ItemType, ReturnType]):
         self.aiohttp_session = None
         self.requests_session = None
 
-    async def _predict_multiple(self, items, **kwargs):
-        """A generic _predict_multiple that stacks and passes items to TensorFlow"""
+    async def _predict_batch(self, items, **kwargs):
+        """A generic _predict_batch that stacks and passes items to TensorFlow"""
         vects = {
             key: np.stack([item[key] for item in items], axis=0) for key in items[0]
         }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,7 +91,7 @@ def api_no_type(event_loop):
         yield client
 
 
-@pytest.mark.parametrize("item", ["ok", ["ok", "ko"]])
+@pytest.mark.parametrize("item", ["ok", "ko"])
 def test_api_simple_type(item, api_no_type):
     res = api_no_type.post(
         "/predict/some_model", headers={"Content-Type": "application/json"}, json=item

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,6 +99,12 @@ def test_api_simple_type(item, api_no_type):
     assert res.status_code == 200
     assert res.json() == item
 
+    res = api_no_type.post(
+        "/predict/batch/some_model", headers={"Content-Type": "application/json"}, json=[item]
+    )
+    assert res.status_code == 200
+    assert res.json() == [item]
+
 
 @pytest.mark.parametrize("item", [{"string": "ok"}])
 def test_api_complex_type(item, api_no_type):
@@ -109,6 +115,14 @@ def test_api_complex_type(item, api_no_type):
     )
     assert res.status_code == 200
     assert res.json()["sorted"] == "".join(sorted(item["string"]))
+
+    res = api_no_type.post(
+        "/predict/batch/some_complex_model",
+        headers={"Content-Type": "application/json"},
+        json=[item],
+    )
+    assert res.status_code == 200
+    assert res.json()[0]["sorted"] == "".join(sorted(item["string"]))
 
 
 def test_api_doc(api_no_type):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_model": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     class ItemModel(pydantic.BaseModel):
@@ -42,19 +42,19 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_complex_model": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return {"sorted": "".join(sorted(item.string))}
 
     class NotValidatedModel(Model):
         CONFIGURATIONS = {"unvalidated_model": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     class ValidationNotSupported(Model[np.ndarray, np.ndarray]):
         CONFIGURATIONS = {"no_supported_model": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     class SomeAsset(Asset):
@@ -64,7 +64,7 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_asset": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return {"sorted": "".join(sorted(item.string))}
 
     router = ModelkitAutoAPIRouter(

--- a/tests/test_auto_testing.py
+++ b/tests/test_auto_testing.py
@@ -26,7 +26,7 @@ class TestableModel(Model[ModelItemType, ModelItemType]):
         ]
     }
 
-    async def _predict_one(self, item, add_one=False):
+    async def _predict(self, item, add_one=False):
         if add_one:
             return {"x": item.x + 1}
         return item
@@ -40,7 +40,7 @@ def test_list_cases():
             cases=[{"item": {"x": 1}, "result": {"x": 1}}]
         )
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     assert list(SomeModel._iterate_test_cases()) == [
@@ -52,7 +52,7 @@ def test_list_cases():
 
         TEST_CASES = {"cases": [{"item": {"x": 1}, "result": {"x": 1}}]}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     assert list(TestableModel._iterate_test_cases()) == [

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -28,7 +28,7 @@ async def test_identitybatch_batch_process(
 ):
 
     m = Model()
-    monkeypatch.setattr(m, "_predict_multiple", func)
+    monkeypatch.setattr(m, "_predict_batch", func)
     if batch_size:
         assert await m._predict_by_batch(items, batch_size=batch_size) == expected
     else:
@@ -60,6 +60,6 @@ async def test_callback_batch_process(items, batch_size, expected_steps, monkeyp
         steps += 1
 
     m = Model()
-    monkeypatch.setattr(m, "_predict_multiple", func)
+    monkeypatch.setattr(m, "_predict_batch", func)
     await m._predict_by_batch(items, batch_size=batch_size, callback=callback)
     assert steps == expected_steps

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -75,7 +75,7 @@ def test_redis_cache(redis_service):
     class SomeModel(Model):
         CONFIGURATIONS = {"model": {"model_settings": {"cache_predictions": True}}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     class SomeModelMultiple(Model):
@@ -83,7 +83,7 @@ def test_redis_cache(redis_service):
             "model_multiple": {"model_settings": {"cache_predictions": True}}
         }
 
-        async def _predict_multiple(self, items):
+        async def _predict_batch(self, items):
             return items
 
     svc = ModelLibrary(

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -50,22 +50,22 @@ async def _do_model_test(model, ITEMS):
         assert i == res
         assert from_cache
 
-    res = model(ITEMS, _return_info=True)
+    res = model.predict_batch(ITEMS, _return_info=True)
     assert [x[0] for x in res] == ITEMS
     assert all([x[1] for x in res])
 
-    res = await model.predict_async(ITEMS, _return_info=True)
+    res = await model.predict_batch_async(ITEMS, _return_info=True)
     assert [x[0] for x in res] == ITEMS
     assert all([x[1] for x in res])
 
     mixed_items = ITEMS + [{"new": "item"}]
-    res = model(mixed_items, _return_info=True)
+    res = model.predict_batch(mixed_items, _return_info=True)
     assert [x[0] for x in res] == mixed_items
     assert all([x[1] for x in res[:-1]])
     assert not res[-1][1]
 
     mixed_items = ITEMS + [{"new": "item"}]
-    res = model(mixed_items, _return_info=True)
+    res = model.predict_batch(mixed_items, _return_info=True)
     assert [x[0] for x in res] == mixed_items
     assert all([x[1] for x in res])
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,11 +26,11 @@ def test_override_asset():
         def _load(self):
             pass
 
-        async def _predict_one(self, item, **kwargs):
+        async def _predict(self, item, **kwargs):
             return self.asset_path
 
     class TestDepModel(Model):
-        async def _predict_one(self, item, **kwargs):
+        async def _predict(self, item, **kwargs):
             return "dep" + self.asset_path
 
     config = {
@@ -209,7 +209,7 @@ def test_lazy_loading_dependencies():
         def _load(self):
             self.some_attribute = self.model_dependencies["model0"].some_attribute
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return self.some_attribute
 
     p = ModelLibrary(models=[Model1, Model0], settings={"lazy_loading": True})
@@ -344,7 +344,7 @@ def test_load_model():
     class SomeModel(Model):
         CONFIGURATIONS = {"model": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     m = load_model("model", models=SomeModel)
@@ -382,7 +382,7 @@ def test_environment_asset_load(monkeypatch, assetsmanager_settings):
             assert self.asset_path == "path/to/asset"
             self.data = {"some key": "some data"}
 
-        async def _predict_one(self, item, **kwargs):
+        async def _predict(self, item, **kwargs):
             return self.data
 
     monkeypatch.setenv("MODELKIT_TESTS_TEST_ASSET_FILE", "path/to/asset")
@@ -406,13 +406,13 @@ def test_rename_dependencies():
     class SomeModel(Model):
         CONFIGURATIONS = {"ok": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return self.configuration_key
 
     class SomeModel2(Model):
         CONFIGURATIONS = {"boomer": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return self.configuration_key
 
     class FinalModel(Model):
@@ -425,7 +425,7 @@ def test_rename_dependencies():
             },
         }
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return self.model_dependencies["ok"](item)
 
     svc = ModelLibrary(models=[SomeModel, SomeModel2, FinalModel])
@@ -435,7 +435,7 @@ def test_rename_dependencies():
 
 def test_override_prefix(assetsmanager_settings):
     class TestModel(Model):
-        async def _predict_one(self, item, **kwargs):
+        async def _predict(self, item, **kwargs):
             return self.asset_path
 
     prediction_service = ModelLibrary(

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -20,7 +20,7 @@ def test_describe():
 
         CONFIGURATIONS = {"some_model_a": {}}
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     class ItemModel(pydantic.BaseModel):
@@ -47,7 +47,7 @@ def test_describe():
             super().__init__(*args, **kwargs)
             self.some_object = A()
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     library = ModelLibrary(

--- a/tests/test_model_serialization.py
+++ b/tests/test_model_serialization.py
@@ -14,7 +14,7 @@ class ReturnType(pydantic.BaseModel):
 
 
 class SomeModel(Model[ItemType, ReturnType]):
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
 
 
@@ -27,7 +27,7 @@ def test_model_serialization():
 
 
 class SomeModelWithoutTypes(Model):
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
 
 

--- a/tests/test_tf_model.py
+++ b/tests/test_tf_model.py
@@ -174,8 +174,8 @@ def _compare_models(model0, model1, items, tolerance=1e-2):
 
     try:
         # Compare two models in batches
-        res_model0_items = model0(items)
-        res_model1_items = model1(items)
+        res_model0_items = model0.predict_batch(items)
+        res_model1_items = model1.predict_batch(items)
         for k in range(len(items)):
             res_model0 = res_model0_items[k]
             res_model1 = res_model1_items[k]
@@ -253,8 +253,8 @@ async def _compare_models_async(model, model_async, items, tolerance=1e-2):
 
     try:
         # Compare two models in batches
-        res_model0_items = model(items)
-        res_model1_items = await model_async.predict_async(items)
+        res_model0_items = model.predict_batch(items)
+        res_model1_items = await model_async.predict_batch_async(items)
         for k in range(len(items)):
             res_model0 = res_model0_items[k]
             res_model1 = res_model1_items[k]

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -24,7 +24,7 @@ def test_validate_item_spec_pydantic(service_settings):
         x: int
 
     class SomeValidatedModel(Model[ItemModel, Any]):
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     valid_test_item = {"x": 10}
@@ -61,8 +61,7 @@ def test_validate_item_spec_pydantic_default(service_settings):
         something_else: str = "ok"
 
     class TypedModel(Model[ItemType, ReturnType]):
-        async def _predict_one(self, item, **kwargs):
-            print(item)
+        async def _predict(self, item, **kwargs):
             return {"result": item.x + len(item.y)}
 
     m = TypedModel(service_settings=service_settings)
@@ -90,7 +89,7 @@ def test_validate_item_spec_pydantic_default(service_settings):
 )
 def test_validate_item_spec_typing(service_settings):
     class SomeValidatedModel(Model[Dict[str, int], Any]):
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     valid_test_item = {"x": 10}
@@ -127,7 +126,7 @@ def test_validate_return_spec(service_settings):
         x: int
 
     class SomeValidatedModel(Model[Any, ItemModel]):
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     m = SomeValidatedModel(service_settings)
@@ -155,7 +154,7 @@ def test_validate_list_items(service_settings):
             self.counter = 0
             super().__init__(*args, **kwargs)
 
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             self.counter += 1
             return item
 
@@ -175,7 +174,7 @@ def test_validate_list_items(service_settings):
 )
 def test_validate_none(service_settings):
     class SomeValidatedModel(Model):
-        async def _predict_one(self, item):
+        async def _predict(self, item):
             return item
 
     m = SomeValidatedModel(service_settings=service_settings)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -41,7 +41,7 @@ def test_validate_item_spec_pydantic(service_settings):
         m({"ok": 1})
         m({"x": "something", "blabli": 10})
 
-    assert m([valid_test_item] * 2) == [valid_test_item] * 2
+    assert m.predict_batch([valid_test_item] * 2) == [valid_test_item] * 2
 
 
 @pytest.mark.parametrize(
@@ -99,19 +99,19 @@ def test_validate_item_spec_typing(service_settings):
 
     if service_settings.enable_validation:
         with pytest.raises(ItemValidationException):
-            m(["ok"])
+            m.predict_batch(["ok"])
 
         with pytest.raises(ItemValidationException):
             m("x")
 
         with pytest.raises(ItemValidationException):
-            m([1, 2, 1])
+            m.predict_batch([1, 2, 1])
     else:
-        m(["ok"])
+        m.predict_batch(["ok"])
         m("x")
-        m([1, 2, 1])
+        m.predict_batch([1, 2, 1])
 
-    assert m([valid_test_item] * 2) == [valid_test_item] * 2
+    assert m.predict_batch([valid_test_item] * 2) == [valid_test_item] * 2
 
 
 @pytest.mark.parametrize(
@@ -159,7 +159,7 @@ def test_validate_list_items(service_settings):
             return item
 
     m = SomeValidatedModel(service_settings=service_settings)
-    m([{"x": 10, "y": "ko"}] * 10)
+    m.predict_batch([{"x": 10, "y": "ko"}] * 10)
     assert m.counter == 10
     m({"x": 10, "y": "ko"})
     assert m.counter == 11

--- a/tests/testdata/api/openapi.json
+++ b/tests/testdata/api/openapi.json
@@ -61,6 +61,176 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/predict/batch/no_supported_model": {
+      "post": {
+        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "operationId": "_endpoint_predict_batch_no_supported_model_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {},
+                "title": "Item",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": " Endpoint",
+        "tags": [
+          "tests.test_api"
+        ]
+      }
+    },
+    "/predict/batch/some_complex_model": {
+      "post": {
+        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "operationId": "_endpoint_predict_batch_some_complex_model_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/ItemModel"
+                },
+                "title": "Item",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "More complex",
+        "tags": [
+          "tests.test_api"
+        ]
+      }
+    },
+    "/predict/batch/some_model": {
+      "post": {
+        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "operationId": "_endpoint_predict_batch_some_model_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {},
+                "title": "Item",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "This is a summary",
+        "tags": [
+          "tests.test_api"
+        ]
+      }
+    },
+    "/predict/batch/unvalidated_model": {
+      "post": {
+        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "operationId": "_endpoint_predict_batch_unvalidated_model_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {},
+                "title": "Item",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": " Endpoint",
+        "tags": [
+          "tests.test_api"
+        ]
+      }
+    },
     "/predict/no_supported_model": {
       "post": {
         "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",

--- a/tests/testdata/api/openapi.json
+++ b/tests/testdata/api/openapi.json
@@ -14,6 +14,19 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "ItemModel": {
+        "properties": {
+          "string": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        "required": [
+          "string"
+        ],
+        "title": "ItemModel",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "loc": {
@@ -96,7 +109,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "title": "Item"
+                "$ref": "#/components/schemas/ItemModel"
               }
             }
           },

--- a/tests/testdata/test_module/module_a.py
+++ b/tests/testdata/test_module/module_a.py
@@ -14,7 +14,7 @@ class SomeSimpleValidatedModelA(Model[str, str]):
 
     CONFIGURATIONS = {"some_model_a": {}}
 
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
 
 
@@ -35,7 +35,7 @@ class SomeComplexValidatedModelA(Model[ItemModel, ResultModel]):
 
     CONFIGURATIONS = {"some_complex_model_a": {}}
 
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return {"sorted": "".join(sorted(item.string))}
 
 

--- a/tests/testdata/test_module/module_b.py
+++ b/tests/testdata/test_module/module_b.py
@@ -12,7 +12,7 @@ class SomeSimpleValidatedModelB(Model[str, str]):
 
     CONFIGURATIONS = {"some_model_b": {}}
 
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
 
 
@@ -33,5 +33,5 @@ class SomeComplexValidatedModelB(Model[ItemModel, ResultModel]):
 
     CONFIGURATIONS = {"some_complex_model_b": {}}
 
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return {"sorted": "".join(sorted(item.string))}

--- a/tests/testdata/typing/predict_bad.py
+++ b/tests/testdata/typing/predict_bad.py
@@ -2,7 +2,7 @@ from modelkit.core.model import Model
 
 
 class BadModel(Model[int, int]):
-    def _predict_one(self, item):
+    def _predict(self, item):
         return item
 
 

--- a/tests/testdata/typing/predict_ok.py
+++ b/tests/testdata/typing/predict_ok.py
@@ -4,7 +4,7 @@ from modelkit.core.model import Model
 
 
 class OKModel(Model[int, int]):
-    def _predict_one(self, item):
+    def _predict(self, item):
         return item
 
 

--- a/tests/testdata/typing/predict_ok.py
+++ b/tests/testdata/typing/predict_ok.py
@@ -10,4 +10,4 @@ class OKModel(Model[int, int]):
 
 m = OKModel()
 y: int = m(1)
-y2: List[int] = m([1])
+y2: List[int] = m.predict_batch([1])

--- a/tests/testdata/typing/predict_pydantic_bad.py
+++ b/tests/testdata/typing/predict_pydantic_bad.py
@@ -8,7 +8,7 @@ class ItemModel(pydantic.BaseModel):
 
 
 class SomeBadValidatedModel(Model[ItemModel, ItemModel]):
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item.x
 
 

--- a/tests/testdata/typing/predict_pydantic_ok.py
+++ b/tests/testdata/typing/predict_pydantic_ok.py
@@ -8,7 +8,7 @@ class ItemModel(pydantic.BaseModel):
 
 
 class SomeValidatedModel(Model[ItemModel, ItemModel]):
-    async def _predict_one(self, item):
+    async def _predict(self, item):
         return item
 
 


### PR DESCRIPTION
In this PR I move away from having the double signature for `Model.predict`: `ItemType->ReturnType` and `List[ItemType]->List[ReturnType]` and rather expose two explicitly different methods:
- `Model[ItemType,ReturnType].predict == Model[ItemType,ReturnType].__call__` with `ItemType->ReturnType` , implemented by `Model._predict`
- `Model[ItemType,ReturnType].predict_batch`  with `List[ItemType]->List[ReturnType]`, implemented by `Model._predict_batch`