### PR TITLE
Separate async and sync models

### DIFF
--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -2,7 +2,7 @@ import copy
 import hashlib
 import pickle  # nosec
 import typing
-from typing import Any, Callable, Dict, Generic, List, Tuple, Union
+from typing import Any, Callable, Dict, Generic, List, Union
 
 import humanize
 import pydantic

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -364,7 +364,7 @@ class BaseModel(Asset, Generic[ItemType, ReturnType]):
 class Model(BaseModel[ItemType, ReturnType]):
     def load(self):
         super().load()
-        """For Model instances, there may be a need to also load the dependencies"""
+        # For asynchronous models, we wrap it to be able to evaluate `.predict`
         for model_name, m in self._model_dependencies.items():
             if isinstance(m, AsyncModel):
                 self._model_dependencies[model_name] = WrappedAsyncModel(m)

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -154,7 +154,7 @@ class ItemValidationException(ModelkitDataValidationException):
         )
 
 
-class Model(Asset, Generic[ItemType, ReturnType]):
+class BaseModel(Asset, Generic[ItemType, ReturnType]):
     """
     Model
     ===
@@ -252,211 +252,6 @@ class Model(Asset, Generic[ItemType, ReturnType]):
         pickled = pickle.dumps((item, kwargs))  # nosec: only used to build a hash
         return hashlib.sha256(self._model_cache_key + pickled).digest()
 
-    def __call__(
-        self,
-        item: ItemType,
-        _force_compute: bool = False,
-        _return_info: bool = False,
-        **kwargs,
-    ) -> ReturnType:
-        return self.predict(
-            item, _force_compute=_force_compute, _return_info=_return_info, **kwargs
-        )
-
-    def predict(
-        self,
-        item: ItemType,
-        _force_compute: bool = False,
-        _return_info: bool = False,
-        **kwargs,
-    ) -> ReturnType:
-        return _run_secretly_sync_async_fn(
-            self.predict_async,
-            item,
-            _force_compute=_force_compute,
-            _return_info=_return_info,
-            **kwargs,
-        )
-
-    async def _predict(self, item: ItemType, **kwargs) -> ReturnType:
-        result = await self._predict_batch([item], **kwargs)
-        return result[0]
-
-    async def predict_async(
-        self,
-        item: ItemType,
-        _force_compute: bool = False,
-        _return_info: bool = False,
-        **kwargs,
-    ) -> Union[ReturnType, Tuple[ReturnType, bool]]:
-        if self._item_model:
-            try:
-                if self.service_settings.enable_validation:
-                    item = self._item_model(data=item).data
-                else:
-                    item = construct_recursive(self._item_model, data=item).data
-            except pydantic.error_wrappers.ValidationError as exc:
-                raise ItemValidationException(
-                    f"{self.__class__.__name__}[{self.configuration_key}]",
-                    pydantic_exc=exc,
-                )
-        from_cache = False
-        if self.redis_cache and self.model_settings.get("cache_predictions"):
-            key = self.item_cache_key(item, kwargs)
-            if not _force_compute and self.redis_cache.exists(key):
-                from_cache = True
-                logger.debug(
-                    "Prediction result fetched from cache",
-                    key=key,
-                    model=self.configuration_key,
-                )
-                results = pickle.loads(self.redis_cache.get(key))  # nosec
-            else:
-                logger.debug(
-                    "No cached prediction result found",
-                    key=key,
-                    model=self.configuration_key,
-                )
-                results = await self._predict(item, **kwargs)
-                self.redis_cache.set(key, pickle.dumps(results))
-        else:
-            results = await self._predict(item, **kwargs)
-
-        if self._return_model:
-            try:
-                if self.service_settings.enable_validation:
-                    results = self._return_model(data=results).data
-                else:
-                    results = construct_recursive(self._return_model, data=results).data
-            except pydantic.error_wrappers.ValidationError as exc:
-                raise ReturnValueValidationException(
-                    self.configuration_key, pydantic_exc=exc
-                )
-        if _return_info:
-            return results, from_cache
-        return results
-
-    def predict_batch(
-        self,
-        items: List[ItemType],
-        callback: Callable = None,
-        batch_size: int = None,
-        _force_compute: bool = False,
-        _return_info: bool = False,
-        **kwargs,
-    ) -> List[ReturnType]:
-        return _run_secretly_sync_async_fn(
-            self.predict_batch_async,
-            items,
-            _force_compute=_force_compute,
-            _return_info=_return_info,
-            callback=callback,
-            batch_size=batch_size,
-            **kwargs,
-        )
-
-    async def predict_batch_async(
-        self,
-        items: List[ItemType],
-        callback: Callable = None,
-        batch_size: int = None,
-        _force_compute: bool = False,
-        _return_info: bool = False,
-        **kwargs,
-    ) -> Union[List[ReturnType], Tuple[List[ReturnType], bool]]:
-        if self._item_model:
-            try:
-                if self.service_settings.enable_validation:
-                    items = [self._item_model(data=item).data for item in items]
-                else:
-                    items = [
-                        construct_recursive(self._item_model, data=item).data
-                        for item in items
-                    ]
-            except pydantic.error_wrappers.ValidationError as exc:
-                raise ItemValidationException(
-                    f"{self.__class__.__name__}[{self.configuration_key}]",
-                    pydantic_exc=exc,
-                )
-        from_cache = False
-        if self.redis_cache and self.model_settings.get("cache_predictions"):
-            # In the case where cache is activated, sieve through
-            # individual items
-            results = []
-            to_compute = []
-            for kitem, item in enumerate(items):
-                key = self.item_cache_key(item, kwargs)
-                if not _force_compute and self.redis_cache.exists(key):
-                    # We trust the data coming from Redis as it's a local cache
-                    unpickled = pickle.loads(self.redis_cache.get(key))  # nosec
-                    if not _return_info:
-                        results.append(unpickled)
-                    else:
-                        results.append((unpickled, True))
-                else:
-                    results.append(None)
-                    to_compute.append((kitem, key, item))
-            computed_results = await self._predict_by_batch(
-                [item[2] for item in to_compute],
-                batch_size=batch_size or self.batch_size,
-                callback=callback,
-                **kwargs,
-            )
-            for ((kitem, key, _), result) in zip(to_compute, computed_results):
-                self.redis_cache.set(key, pickle.dumps(result))
-                if not _return_info:
-                    results[kitem] = result
-                else:
-                    results[kitem] = (result, False)
-            logger.debug(
-                "Caching digest",
-                recomputed=len(computed_results),
-                from_cache=(len(results) - len(computed_results)),
-                model=self.configuration_key,
-            )
-            return results
-        else:
-            # general case: items is a list of items to treat
-            # if there are multiple examples but no batching
-            # or if there are multiple examples and batching
-            results = await self._predict_by_batch(
-                items,
-                batch_size=batch_size or self.batch_size,
-                callback=callback,
-                **kwargs,
-            )
-        if self._return_model:
-            try:
-                if self.service_settings.enable_validation:
-                    results = [self._return_model(data=item).data for item in results]
-                else:
-                    results = [
-                        construct_recursive(self._return_model, data=item).data
-                        for item in results
-                    ]
-            except pydantic.error_wrappers.ValidationError as exc:
-                raise ReturnValueValidationException(
-                    self.configuration_key, pydantic_exc=exc
-                )
-        if _return_info:
-            return results, from_cache
-        return results
-
-    async def _predict_by_batch(
-        self, items: List[ItemType], batch_size=64, callback=None, **kwargs
-    ) -> List[ReturnType]:
-        predictions = []
-        for step in range(0, len(items), batch_size):
-            batch = items[step : step + batch_size]
-            current_predictions = await self._predict_batch(batch, **kwargs)
-            predictions.extend(current_predictions)
-            if callback:
-                callback(step, batch, current_predictions)
-        return predictions
-
-    async def _predict_batch(self, items: List[ItemType], **kwargs) -> List[ReturnType]:
-        return [await self._predict(p, **kwargs) for p in items]
-
     @classmethod
     def _iterate_test_cases(cls, model_keys=None):
         if not hasattr(cls, "TEST_CASES"):
@@ -531,3 +326,361 @@ class Model(Asset, Generic[ItemType, ReturnType]):
             describe(self.model_settings, t=sub_t)
 
         return t
+
+
+class Model(BaseModel[ItemType, ReturnType]):
+    def __call__(
+        self,
+        item: ItemType,
+        _force_compute: bool = False,
+        _return_info: bool = False,
+        **kwargs,
+    ) -> ReturnType:
+        return self.predict(item, _force_compute=_force_compute, **kwargs)
+
+    def _predict(self, item: ItemType, **kwargs) -> ReturnType:
+        result = self._predict_batch([item], **kwargs)
+        return result[0]
+
+    def predict(
+        self,
+        item: ItemType,
+        _force_compute: bool = False,
+        _return_info: bool = False,
+        **kwargs,
+    ) -> ReturnType:
+        if self._item_model:
+            try:
+                if self.service_settings.enable_validation:
+                    item = self._item_model(data=item).data
+                else:
+                    item = construct_recursive(self._item_model, data=item).data
+            except pydantic.error_wrappers.ValidationError as exc:
+                raise ItemValidationException(
+                    f"{self.__class__.__name__}[{self.configuration_key}]",
+                    pydantic_exc=exc,
+                )
+        if self.redis_cache and self.model_settings.get("cache_predictions"):
+            key = self.item_cache_key(item, kwargs)
+            if not _force_compute and self.redis_cache.exists(key):
+                logger.debug(
+                    "Prediction result fetched from cache",
+                    key=key,
+                    model=self.configuration_key,
+                )
+                results = pickle.loads(self.redis_cache.get(key))  # nosec
+            else:
+                logger.debug(
+                    "No cached prediction result found",
+                    key=key,
+                    model=self.configuration_key,
+                )
+                results = self._predict(item, **kwargs)
+                self.redis_cache.set(key, pickle.dumps(results))
+        else:
+            results = self._predict(item, **kwargs)
+
+        if self._return_model:
+            try:
+                if self.service_settings.enable_validation:
+                    results = self._return_model(data=results).data
+                else:
+                    results = construct_recursive(self._return_model, data=results).data
+            except pydantic.error_wrappers.ValidationError as exc:
+                raise ReturnValueValidationException(
+                    self.configuration_key, pydantic_exc=exc
+                )
+        return results
+
+    def predict_batch(
+        self,
+        items: List[ItemType],
+        callback: Callable = None,
+        batch_size: int = None,
+        _force_compute: bool = False,
+        _return_info: bool = False,
+        **kwargs,
+    ) -> List[ReturnType]:
+        if self._item_model:
+            try:
+                if self.service_settings.enable_validation:
+                    items = [self._item_model(data=item).data for item in items]
+                else:
+                    items = [
+                        construct_recursive(self._item_model, data=item).data
+                        for item in items
+                    ]
+            except pydantic.error_wrappers.ValidationError as exc:
+                raise ItemValidationException(
+                    f"{self.__class__.__name__}[{self.configuration_key}]",
+                    pydantic_exc=exc,
+                )
+        if self.redis_cache and self.model_settings.get("cache_predictions"):
+            # In the case where cache is activated, sieve through
+            # individual items
+            results = []
+            to_compute = []
+            for kitem, item in enumerate(items):
+                key = self.item_cache_key(item, kwargs)
+                if not _force_compute and self.redis_cache.exists(key):
+                    # We trust the data coming from Redis as it's a local cache
+                    unpickled = pickle.loads(self.redis_cache.get(key))  # nosec
+                    if not _return_info:
+                        results.append(unpickled)
+                    else:
+                        results.append((unpickled, True))
+                else:
+                    results.append(None)
+                    to_compute.append((kitem, key, item))
+            computed_results = self._predict_by_batch(
+                [item[2] for item in to_compute],
+                batch_size=batch_size or self.batch_size,
+                callback=callback,
+                **kwargs,
+            )
+            for ((kitem, key, _), result) in zip(to_compute, computed_results):
+                self.redis_cache.set(key, pickle.dumps(result))
+                if not _return_info:
+                    results[kitem] = result
+                else:
+                    results[kitem] = (result, False)
+            logger.debug(
+                "Caching digest",
+                recomputed=len(computed_results),
+                from_cache=(len(results) - len(computed_results)),
+                model=self.configuration_key,
+            )
+            return results
+        else:
+            # general case: items is a list of items to treat
+            # if there are multiple examples but no batching
+            # or if there are multiple examples and batching
+            results = self._predict_by_batch(
+                items,
+                batch_size=batch_size or self.batch_size,
+                callback=callback,
+                **kwargs,
+            )
+        if self._return_model:
+            try:
+                if self.service_settings.enable_validation:
+                    results = [self._return_model(data=item).data for item in results]
+                else:
+                    results = [
+                        construct_recursive(self._return_model, data=item).data
+                        for item in results
+                    ]
+            except pydantic.error_wrappers.ValidationError as exc:
+                raise ReturnValueValidationException(
+                    self.configuration_key, pydantic_exc=exc
+                )
+        return results
+
+    def _predict_by_batch(
+        self, items: List[ItemType], batch_size=64, callback=None, **kwargs
+    ) -> List[ReturnType]:
+        predictions = []
+        for step in range(0, len(items), batch_size):
+            batch = items[step : step + batch_size]
+            current_predictions = self._predict_batch(batch, **kwargs)
+            predictions.extend(current_predictions)
+            if callback:
+                callback(step, batch, current_predictions)
+        return predictions
+
+    def _predict_batch(self, items: List[ItemType], **kwargs) -> List[ReturnType]:
+        return [self._predict(p, **kwargs) for p in items]
+
+
+class AsyncModel(BaseModel[ItemType, ReturnType]):
+    def __call__(
+        self,
+        item: ItemType,
+        _force_compute: bool = False,
+        **kwargs,
+    ) -> ReturnType:
+        return self.predict(item, _force_compute=_force_compute, **kwargs)
+
+    def predict(
+        self,
+        item: ItemType,
+        _force_compute: bool = False,
+        **kwargs,
+    ) -> ReturnType:
+        return _run_secretly_sync_async_fn(
+            self.predict_async,
+            item,
+            _force_compute=_force_compute,
+            **kwargs,
+        )
+
+    async def _predict(self, item: ItemType, **kwargs) -> ReturnType:
+        result = await self._predict_batch([item], **kwargs)
+        return result[0]
+
+    async def predict_async(
+        self,
+        item: ItemType,
+        _force_compute: bool = False,
+        **kwargs,
+    ) -> ReturnType:
+        if self._item_model:
+            try:
+                if self.service_settings.enable_validation:
+                    item = self._item_model(data=item).data
+                else:
+                    item = construct_recursive(self._item_model, data=item).data
+            except pydantic.error_wrappers.ValidationError as exc:
+                raise ItemValidationException(
+                    f"{self.__class__.__name__}[{self.configuration_key}]",
+                    pydantic_exc=exc,
+                )
+        if self.redis_cache and self.model_settings.get("cache_predictions"):
+            key = self.item_cache_key(item, kwargs)
+            if not _force_compute and self.redis_cache.exists(key):
+                logger.debug(
+                    "Prediction result fetched from cache",
+                    key=key,
+                    model=self.configuration_key,
+                )
+                results = pickle.loads(self.redis_cache.get(key))  # nosec
+            else:
+                logger.debug(
+                    "No cached prediction result found",
+                    key=key,
+                    model=self.configuration_key,
+                )
+                results = await self._predict(item, **kwargs)
+                self.redis_cache.set(key, pickle.dumps(results))
+        else:
+            results = await self._predict(item, **kwargs)
+
+        if self._return_model:
+            try:
+                if self.service_settings.enable_validation:
+                    results = self._return_model(data=results).data
+                else:
+                    results = construct_recursive(self._return_model, data=results).data
+            except pydantic.error_wrappers.ValidationError as exc:
+                raise ReturnValueValidationException(
+                    self.configuration_key, pydantic_exc=exc
+                )
+        return results
+
+    def predict_batch(
+        self,
+        items: List[ItemType],
+        callback: Callable = None,
+        batch_size: int = None,
+        _force_compute: bool = False,
+        _return_info: bool = False,
+        **kwargs,
+    ) -> List[ReturnType]:
+        return _run_secretly_sync_async_fn(
+            self.predict_batch_async,
+            items,
+            _force_compute=_force_compute,
+            _return_info=_return_info,
+            callback=callback,
+            batch_size=batch_size,
+            **kwargs,
+        )
+
+    async def predict_batch_async(
+        self,
+        items: List[ItemType],
+        callback: Callable = None,
+        batch_size: int = None,
+        _force_compute: bool = False,
+        _return_info: bool = False,
+        **kwargs,
+    ) -> List[ReturnType]:
+        if self._item_model:
+            try:
+                if self.service_settings.enable_validation:
+                    items = [self._item_model(data=item).data for item in items]
+                else:
+                    items = [
+                        construct_recursive(self._item_model, data=item).data
+                        for item in items
+                    ]
+            except pydantic.error_wrappers.ValidationError as exc:
+                raise ItemValidationException(
+                    f"{self.__class__.__name__}[{self.configuration_key}]",
+                    pydantic_exc=exc,
+                )
+        if self.redis_cache and self.model_settings.get("cache_predictions"):
+            # In the case where cache is activated, sieve through
+            # individual items
+            results = []
+            to_compute = []
+            for kitem, item in enumerate(items):
+                key = self.item_cache_key(item, kwargs)
+                if not _force_compute and self.redis_cache.exists(key):
+                    # We trust the data coming from Redis as it's a local cache
+                    unpickled = pickle.loads(self.redis_cache.get(key))  # nosec
+                    if not _return_info:
+                        results.append(unpickled)
+                    else:
+                        results.append((unpickled, True))
+                else:
+                    results.append(None)
+                    to_compute.append((kitem, key, item))
+            computed_results = await self._predict_by_batch(
+                [item[2] for item in to_compute],
+                batch_size=batch_size or self.batch_size,
+                callback=callback,
+                **kwargs,
+            )
+            for ((kitem, key, _), result) in zip(to_compute, computed_results):
+                self.redis_cache.set(key, pickle.dumps(result))
+                if not _return_info:
+                    results[kitem] = result
+                else:
+                    results[kitem] = (result, False)
+            logger.debug(
+                "Caching digest",
+                recomputed=len(computed_results),
+                from_cache=(len(results) - len(computed_results)),
+                model=self.configuration_key,
+            )
+            return results
+        else:
+            # general case: items is a list of items to treat
+            # if there are multiple examples but no batching
+            # or if there are multiple examples and batching
+            results = await self._predict_by_batch(
+                items,
+                batch_size=batch_size or self.batch_size,
+                callback=callback,
+                **kwargs,
+            )
+        if self._return_model:
+            try:
+                if self.service_settings.enable_validation:
+                    results = [self._return_model(data=item).data for item in results]
+                else:
+                    results = [
+                        construct_recursive(self._return_model, data=item).data
+                        for item in results
+                    ]
+            except pydantic.error_wrappers.ValidationError as exc:
+                raise ReturnValueValidationException(
+                    self.configuration_key, pydantic_exc=exc
+                )
+        return results
+
+    async def _predict_by_batch(
+        self, items: List[ItemType], batch_size=64, callback=None, **kwargs
+    ) -> List[ReturnType]:
+        predictions = []
+        for step in range(0, len(items), batch_size):
+            batch = items[step : step + batch_size]
+            current_predictions = await self._predict_batch(batch, **kwargs)
+            predictions.extend(current_predictions)
+            if callback:
+                callback(step, batch, current_predictions)
+        return predictions
+
+    async def _predict_batch(self, items: List[ItemType], **kwargs) -> List[ReturnType]:
+        return [await self._predict(p, **kwargs) for p in items]

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -614,8 +614,8 @@ class WrappedAsyncModel:
     def __init__(self, async_model: AsyncModel):
         self.async_model = async_model
 
-    def predict(self, item):
-        return asyncio.run(self.async_model.predict(item))
+    def predict(self, item, **kwargs):
+        return asyncio.run(self.async_model.predict(item, **kwargs))
 
-    def predict_batch(self, items):
-        return asyncio.run(self.async_model.predict_batch(items))
+    def predict_batch(self, items, **kwargs):
+        return asyncio.run(self.async_model.predict_batch(items, **kwargs))

--- a/modelkit/core/models/distant_model.py
+++ b/modelkit/core/models/distant_model.py
@@ -11,7 +11,7 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from modelkit.core.model import Model
+from modelkit.core.model import AsyncModel
 from modelkit.core.types import ItemType, ReturnType
 
 logger = get_logger(__name__)
@@ -46,7 +46,7 @@ SERVICE_MODEL_RETRY_POLICY = {
 }
 
 
-class DistantHTTPModel(Model[ItemType, ReturnType]):
+class DistantHTTPModel(AsyncModel[ItemType, ReturnType]):
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
         self.endpoint = self.model_settings["endpoint"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_model": {}}
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     class ItemModel(pydantic.BaseModel):
@@ -42,19 +42,19 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_complex_model": {}}
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return {"sorted": "".join(sorted(item.string))}
 
     class NotValidatedModel(Model):
         CONFIGURATIONS = {"unvalidated_model": {}}
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     class ValidationNotSupported(Model[np.ndarray, np.ndarray]):
         CONFIGURATIONS = {"no_supported_model": {}}
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     class SomeAsset(Asset):
@@ -64,7 +64,7 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_asset": {}}
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return {"sorted": "".join(sorted(item.string))}
 
     router = ModelkitAutoAPIRouter(
@@ -100,7 +100,9 @@ def test_api_simple_type(item, api_no_type):
     assert res.json() == item
 
     res = api_no_type.post(
-        "/predict/batch/some_model", headers={"Content-Type": "application/json"}, json=[item]
+        "/predict/batch/some_model",
+        headers={"Content-Type": "application/json"},
+        json=[item],
     )
     assert res.status_code == 200
     assert res.json() == [item]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ from modelkit.core.model import Asset, Model
 from tests import TEST_DIR
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def api_no_type(event_loop):
     class SomeSimpleValidatedModel(Model[str, str]):
         """

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from modelkit.core.library import ModelLibrary
+from modelkit.core.model import AsyncModel, Model
+
+
+def test_compose_sync_async():
+    class SomeAsyncModel(AsyncModel):
+        CONFIGURATIONS = {"async_model": {}}
+
+        async def _predict(self, item, **kwargs):
+            await asyncio.sleep(0.1)
+            return item
+
+    class ComposedModel(Model):
+        CONFIGURATIONS = {"composed_model": {"model_dependencies": {"async_model"}}}
+
+        def _predict(self, item, **kwargs):
+            return self.model_dependencies["async_model"].predict(item)
+
+    library = ModelLibrary(models=[SomeAsyncModel, ComposedModel])
+    m = library.get("composed_model")
+    assert m.predict({"hello": "world"}) == {"hello": "world"}

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from modelkit.core.library import ModelLibrary
 from modelkit.core.model import AsyncModel, Model
 
@@ -21,3 +23,27 @@ def test_compose_sync_async():
     library = ModelLibrary(models=[SomeAsyncModel, ComposedModel])
     m = library.get("composed_model")
     assert m.predict({"hello": "world"}) == {"hello": "world"}
+
+
+async def _do_async(model, item):
+    res = await model.predict(item)
+    assert item == res
+
+    res = await model.predict_batch([item] * 10)
+    assert [item] * 10 == res
+
+
+def test_async_predict():
+    class SomeModel(AsyncModel):
+        async def _predict(self, item, **kwargs):
+            await asyncio.sleep(0.1)
+            return item
+
+    m = SomeModel()
+    with pytest.raises(AssertionError):
+        assert m.predict({}) == {}
+    with pytest.raises(AssertionError):
+        assert m.predict_batch([{}]) == [{}]
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_do_async(m, {}))

--- a/tests/test_auto_testing.py
+++ b/tests/test_auto_testing.py
@@ -26,7 +26,7 @@ class TestableModel(Model[ModelItemType, ModelItemType]):
         ]
     }
 
-    async def _predict(self, item, add_one=False):
+    def _predict(self, item, add_one=False):
         if add_one:
             return {"x": item.x + 1}
         return item
@@ -40,7 +40,7 @@ def test_list_cases():
             cases=[{"item": {"x": 1}, "result": {"x": 1}}]
         )
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     assert list(SomeModel._iterate_test_cases()) == [
@@ -52,7 +52,7 @@ def test_list_cases():
 
         TEST_CASES = {"cases": [{"item": {"x": 1}, "result": {"x": 1}}]}
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     assert list(TestableModel._iterate_test_cases()) == [

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -3,11 +3,11 @@ import pytest
 from modelkit.core.model import Model
 
 
-async def _identity(x):
+def _identity(x):
     return x
 
 
-async def _double(x):
+def _double(x):
     return [y * 2 for y in x]
 
 
@@ -23,19 +23,16 @@ async def _double(x):
         (_double, [1, 2, 3], 128, [2, 4, 6]),
     ],
 )
-async def test_identitybatch_batch_process(
-    func, items, batch_size, expected, monkeypatch
-):
+def test_identitybatch_batch_process(func, items, batch_size, expected, monkeypatch):
 
     m = Model()
     monkeypatch.setattr(m, "_predict_batch", func)
     if batch_size:
-        assert await m._predict_by_batch(items, batch_size=batch_size) == expected
+        assert m._predict_by_batch(items, batch_size=batch_size) == expected
     else:
-        assert await m._predict_by_batch(items) == expected
+        assert m._predict_by_batch(items) == expected
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "items,batch_size,expected_steps",
     [
@@ -47,10 +44,10 @@ async def test_identitybatch_batch_process(
         (list(range(128)), 63, 3),
     ],
 )
-async def test_callback_batch_process(items, batch_size, expected_steps, monkeypatch):
+def test_callback_batch_process(items, batch_size, expected_steps, monkeypatch):
     steps = 0
 
-    async def func(items):
+    def func(items):
         return [item + 1 for item in items]
 
     def callback(batch_step, batch_items, batch_results):
@@ -61,5 +58,5 @@ async def test_callback_batch_process(items, batch_size, expected_steps, monkeyp
 
     m = Model()
     monkeypatch.setattr(m, "_predict_batch", func)
-    await m._predict_by_batch(items, batch_size=batch_size, callback=callback)
+    m._predict_by_batch(items, batch_size=batch_size, callback=callback)
     assert steps == expected_steps

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -75,7 +75,7 @@ def test_redis_cache(redis_service):
     class SomeModel(Model):
         CONFIGURATIONS = {"model": {"model_settings": {"cache_predictions": True}}}
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     class SomeModelMultiple(Model):
@@ -83,7 +83,7 @@ def test_redis_cache(redis_service):
             "model_multiple": {"model_settings": {"cache_predictions": True}}
         }
 
-        async def _predict_batch(self, items):
+        def _predict_batch(self, items):
             return items
 
     svc = ModelLibrary(

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import subprocess
 import time
@@ -7,7 +6,7 @@ import pytest
 import redis
 
 from modelkit.core.library import ModelLibrary
-from modelkit.core.model import Model
+from modelkit.core.model import AsyncModel, Model
 from tests.conftest import skip_unless
 
 
@@ -39,35 +38,14 @@ def redis_service(request):
     yield
 
 
-async def _do_model_test(model, ITEMS):
+def _do_model_test(model, ITEMS):
     for i in ITEMS:
-        res, from_cache = model(i, _force_compute=True, _return_info=True)
+        res = model(i, _force_compute=True)
         assert i == res
-        assert not from_cache
 
-    for i in ITEMS:
-        res, from_cache = model(i, _return_info=True)
-        assert i == res
-        assert from_cache
+    assert model.predict_batch(ITEMS) == ITEMS
 
-    res = model.predict_batch(ITEMS, _return_info=True)
-    assert [x[0] for x in res] == ITEMS
-    assert all([x[1] for x in res])
-
-    res = await model.predict_batch_async(ITEMS, _return_info=True)
-    assert [x[0] for x in res] == ITEMS
-    assert all([x[1] for x in res])
-
-    mixed_items = ITEMS + [{"new": "item"}]
-    res = model.predict_batch(mixed_items, _return_info=True)
-    assert [x[0] for x in res] == mixed_items
-    assert all([x[1] for x in res[:-1]])
-    assert not res[-1][1]
-
-    mixed_items = ITEMS + [{"new": "item"}]
-    res = model.predict_batch(mixed_items, _return_info=True)
-    assert [x[0] for x in res] == mixed_items
-    assert all([x[1] for x in res])
+    assert ITEMS + [{"new": "item"}] == model.predict_batch(ITEMS + [{"new": "item"}])
 
 
 @skip_unless("ENABLE_REDIS_TEST", "True")
@@ -96,7 +74,49 @@ def test_redis_cache(redis_service):
 
     ITEMS = [{"ok": {"boomer": 1}}, {"ok": {"boomer": [2, 2, 3]}}]
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(_do_model_test(m, ITEMS))
-    loop.run_until_complete(_do_model_test(m_multi, ITEMS))
-    loop.run_until_complete(svc.close_connections())
+    _do_model_test(m, ITEMS)
+    _do_model_test(m_multi, ITEMS)
+
+
+async def _do_model_test_async(model, ITEMS):
+    for i in ITEMS:
+        res = await model(i, _force_compute=True)
+        assert i == res
+
+    res = await model.predict_batch(ITEMS)
+    assert res == ITEMS
+
+    res = await model.predict_batch(ITEMS + [{"new": "item"}])
+    assert ITEMS + [{"new": "item"}] == res
+
+
+@pytest.mark.asyncio
+@skip_unless("ENABLE_REDIS_TEST", "True")
+async def test_redis_cache_async(redis_service, event_loop):
+    class SomeModel(AsyncModel):
+        CONFIGURATIONS = {"model": {"model_settings": {"cache_predictions": True}}}
+
+        async def _predict(self, item):
+            return item
+
+    class SomeModelMultiple(AsyncModel):
+        CONFIGURATIONS = {
+            "model_multiple": {"model_settings": {"cache_predictions": True}}
+        }
+
+        async def _predict_batch(self, items):
+            return items
+
+    svc = ModelLibrary(
+        models=[SomeModel, SomeModelMultiple],
+        settings={"redis": {"enable": True}},
+    )
+
+    m = svc.get("model")
+    m_multi = svc.get("model_multiple")
+
+    ITEMS = [{"ok": {"boomer": 1}}, {"ok": {"boomer": [2, 2, 3]}}]
+
+    await _do_model_test_async(m, ITEMS)
+    await _do_model_test_async(m_multi, ITEMS)
+    await svc.close_connections()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 
 import pytest
@@ -10,7 +9,7 @@ from modelkit.core.library import (
     download_assets,
     load_model,
 )
-from modelkit.core.model import Asset, AsyncModel, Model, NoModelDependenciesInInitError
+from modelkit.core.model import Asset, Model, NoModelDependenciesInInitError
 from modelkit.core.model_configuration import (
     ModelConfiguration,
     _configurations_from_objects,
@@ -477,27 +476,3 @@ def test_override_prefix(assetsmanager_settings):
 
     prediction = prediction_service.get("my_override_model")({})
     assert prediction.endswith(os.path.join("category", "override-asset", "1.0"))
-
-
-async def _do_async(model, item):
-    res = await model.predict_async(item)
-    assert item == res
-
-    res = await model.predict_batch_async([item] * 10)
-    assert [item] * 10 == res
-
-
-def test_async_predict():
-    class SomeModel(AsyncModel):
-        async def _predict(self, item, **kwargs):
-            await asyncio.sleep(0.1)
-            return item
-
-    m = SomeModel()
-    with pytest.raises(RuntimeError):
-        assert m.predict({}) == {}
-    with pytest.raises(RuntimeError):
-        assert m.predict_batch([{}]) == [{}]
-
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(_do_async(m, {}))

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -20,7 +20,7 @@ def test_describe():
 
         CONFIGURATIONS = {"some_model_a": {}}
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     class ItemModel(pydantic.BaseModel):
@@ -47,7 +47,7 @@ def test_describe():
             super().__init__(*args, **kwargs)
             self.some_object = A()
 
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     library = ModelLibrary(

--- a/tests/test_model_serialization.py
+++ b/tests/test_model_serialization.py
@@ -14,7 +14,7 @@ class ReturnType(pydantic.BaseModel):
 
 
 class SomeModel(Model[ItemType, ReturnType]):
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 
 
@@ -27,7 +27,7 @@ def test_model_serialization():
 
 
 class SomeModelWithoutTypes(Model):
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -24,7 +24,7 @@ def test_validate_item_spec_pydantic(service_settings):
         x: int
 
     class SomeValidatedModel(Model[ItemModel, Any]):
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     valid_test_item = {"x": 10}
@@ -61,7 +61,7 @@ def test_validate_item_spec_pydantic_default(service_settings):
         something_else: str = "ok"
 
     class TypedModel(Model[ItemType, ReturnType]):
-        async def _predict(self, item, **kwargs):
+        def _predict(self, item, **kwargs):
             return {"result": item.x + len(item.y)}
 
     m = TypedModel(service_settings=service_settings)
@@ -89,7 +89,7 @@ def test_validate_item_spec_pydantic_default(service_settings):
 )
 def test_validate_item_spec_typing(service_settings):
     class SomeValidatedModel(Model[Dict[str, int], Any]):
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     valid_test_item = {"x": 10}
@@ -126,7 +126,7 @@ def test_validate_return_spec(service_settings):
         x: int
 
     class SomeValidatedModel(Model[Any, ItemModel]):
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     m = SomeValidatedModel(service_settings)
@@ -154,7 +154,7 @@ def test_validate_list_items(service_settings):
             self.counter = 0
             super().__init__(*args, **kwargs)
 
-        async def _predict(self, item):
+        def _predict(self, item):
             self.counter += 1
             return item
 
@@ -174,7 +174,7 @@ def test_validate_list_items(service_settings):
 )
 def test_validate_none(service_settings):
     class SomeValidatedModel(Model):
-        async def _predict(self, item):
+        def _predict(self, item):
             return item
 
     m = SomeValidatedModel(service_settings=service_settings)

--- a/tests/testdata/test_module/module_a.py
+++ b/tests/testdata/test_module/module_a.py
@@ -14,7 +14,7 @@ class SomeSimpleValidatedModelA(Model[str, str]):
 
     CONFIGURATIONS = {"some_model_a": {}}
 
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 
 
@@ -35,7 +35,7 @@ class SomeComplexValidatedModelA(Model[ItemModel, ResultModel]):
 
     CONFIGURATIONS = {"some_complex_model_a": {}}
 
-    async def _predict(self, item):
+    def _predict(self, item):
         return {"sorted": "".join(sorted(item.string))}
 
 

--- a/tests/testdata/test_module/module_b.py
+++ b/tests/testdata/test_module/module_b.py
@@ -12,7 +12,7 @@ class SomeSimpleValidatedModelB(Model[str, str]):
 
     CONFIGURATIONS = {"some_model_b": {}}
 
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 
 
@@ -33,5 +33,5 @@ class SomeComplexValidatedModelB(Model[ItemModel, ResultModel]):
 
     CONFIGURATIONS = {"some_complex_model_b": {}}
 
-    async def _predict(self, item):
+    def _predict(self, item):
         return {"sorted": "".join(sorted(item.string))}

--- a/tests/testdata/typing/predict_pydantic_bad.py
+++ b/tests/testdata/typing/predict_pydantic_bad.py
@@ -8,7 +8,7 @@ class ItemModel(pydantic.BaseModel):
 
 
 class SomeBadValidatedModel(Model[ItemModel, ItemModel]):
-    async def _predict(self, item):
+    def _predict(self, item):
         return item.x
 
 

--- a/tests/testdata/typing/predict_pydantic_ok.py
+++ b/tests/testdata/typing/predict_pydantic_ok.py
@@ -8,7 +8,7 @@ class ItemModel(pydantic.BaseModel):
 
 
 class SomeValidatedModel(Model[ItemModel, ItemModel]):
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 
 


### PR DESCRIPTION
Previously, sync and async logics were conflated, such that all `Model`s had to implement a `async def _predict*` instead of just `_predict*`. 

This is confusing, and leads to a log of magic happening. 

Here, I split the models into `Model` (with sync predict/predict_batch) and `AsyncModel` with async `predict` and `predict_batch`.

This leads to a number of changes:
- I create a `BaseModel` class that gathers all the sync logic that is common between Model and AsyncModel. This comprises the validation logic, description, etc. I then create both `Model` and `AsyncModel` from this class.
- Neither `TensorflowModel` nor `DistantHTTPModel` can automatically pick between the two, or choose at runtime (e.g. using `TF_SERVING_MODE="rest-async"`, or checking for an event loop). I split these models into a sync and an async version too
- We want to make sure that a sync colored model can still call an async model. To do so, I wrap async models in a special class that uses `asyncio.run` to run the coroutines. Since doing so terminates event loops, that forces me to rewrite a bunch of the test code to use `pytest.mark.asyncio` and run their own event loop.
