### PR TITLE
test-api: remove load time and load memory from descriptions before c…

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,6 +125,21 @@ def test_api_complex_type(item, api_no_type):
     assert res.json()[0]["sorted"] == "".join(sorted(item["string"]))
 
 
+EXCLUDED = ["load time", "load memory"]
+
+
+def _strip_description_fields(spec):
+    if isinstance(spec, str):
+        return "\n".join(
+            line for line in spec.split("\n") if not any(x in line for x in EXCLUDED)
+        )
+    if isinstance(spec, list):
+        return [_strip_description_fields(x) for x in spec]
+    if isinstance(spec, dict):
+        return {key: _strip_description_fields(value) for key, value in spec.items()}
+    return spec
+
+
 def test_api_doc(api_no_type):
     r = testing.ReferenceJson(os.path.join(TEST_DIR, "testdata", "api"))
     res = api_no_type.get(
@@ -134,4 +149,4 @@ def test_api_doc(api_no_type):
         # Output is different on Windows platforms since
         # modelkit.utils.memory cannot track memory increment
         # and write it
-        r.assert_equal("openapi.json", res.json())
+        r.assert_equal("openapi.json", _strip_description_fields(res.json()))

--- a/tests/testdata/api/openapi.json
+++ b/tests/testdata/api/openapi.json
@@ -63,7 +63,7 @@
   "paths": {
     "/predict/batch/no_supported_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n└── batch size: 64                                                              \n```",
         "operationId": "_endpoint_predict_batch_no_supported_model_post",
         "requestBody": {
           "content": {
@@ -105,7 +105,7 @@
     },
     "/predict/batch/some_complex_model": {
       "post": {
-        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n└── batch size: 64                                                              \n```",
         "operationId": "_endpoint_predict_batch_some_complex_model_post",
         "requestBody": {
           "content": {
@@ -149,7 +149,7 @@
     },
     "/predict/batch/some_model": {
       "post": {
-        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n└── batch size: 64                                                              \n```",
         "operationId": "_endpoint_predict_batch_some_model_post",
         "requestBody": {
           "content": {
@@ -191,7 +191,7 @@
     },
     "/predict/batch/unvalidated_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n└── batch size: 64                                                              \n```",
         "operationId": "_endpoint_predict_batch_unvalidated_model_post",
         "requestBody": {
           "content": {
@@ -233,7 +233,7 @@
     },
     "/predict/no_supported_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n└── batch size: 64                                                              \n```",
         "operationId": "_endpoint_predict_no_supported_model_post",
         "requestBody": {
           "content": {
@@ -273,7 +273,7 @@
     },
     "/predict/some_complex_model": {
       "post": {
-        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n└── batch size: 64                                                              \n```",
         "operationId": "_endpoint_predict_some_complex_model_post",
         "requestBody": {
           "content": {
@@ -313,7 +313,7 @@
     },
     "/predict/some_model": {
       "post": {
-        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n└── batch size: 64                                                              \n```",
         "operationId": "_endpoint_predict_some_model_post",
         "requestBody": {
           "content": {
@@ -353,7 +353,7 @@
     },
     "/predict/unvalidated_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n├── load time: 0 microseconds                                                   \n├── load memory: 0 Bytes                                                        \n└── batch size: 64                                                              \n```",
+        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n└── batch size: 64                                                              \n```",
         "operationId": "_endpoint_predict_unvalidated_model_post",
         "requestBody": {
           "content": {


### PR DESCRIPTION
The API description is tested exactly, but it contains information such as load time and memory consumption of models that is not very reliable.

Here, I strip this information from the openapi.json such that the test is more reliable.