### PR TITLE
ci: only run coverage on linux

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,15 @@ def test(session):
     session.install("-r", "requirements-dev.txt")
 
     session.run(
+        "pytest"
+    )
+
+@nox.session(python=["3.7"])
+def coverage(session):
+    # Install deps and the package itself.
+    session.install("-r", "requirements-dev.txt")
+
+    session.run(
         "coverage",
         "run",
         "-m",

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -5,6 +5,7 @@ if [[ $OS_NAME == "ubuntu-latest" ]]; then
     export ENABLE_REDIS_TEST=True
     export ENABLE_S3_TEST=True
     export ENABLE_GCS_TEST=True
+    nox -s coverage
+else
+    nox -s test
 fi
-
-nox -s test

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ omit =
 	modelkit/cli.py
 
 [coverage:report]
-fail_under = 80
+fail_under = 90
 precision = 2
 
 [mypy]


### PR DESCRIPTION
On OSX and Windows, coverage is limited because docker is not run (hence services are not mocked)
Only run coverage on linux, and regular tests otherwise