### PR TITLE
asset path: replace asset by asset_path

### DIFF
--- a/docs/assets/assets.md
+++ b/docs/assets/assets.md
@@ -48,7 +48,7 @@ In this case it returns a dictionary with:
 
 ```
 {
-  "path": "/local/path/to/asset",
+  "asset_path": "/local/path/to/asset",
   "from_cache": whether the asset was pulled from cache,
   "meta": {contents of the meta JSON object},
   "version": "returned asset version",

--- a/docs/library/developing_modelkit.md
+++ b/docs/library/developing_modelkit.md
@@ -123,7 +123,7 @@ Adding the key to the model's configuration:
 ```python
 class ModelWithAsset(Model):
     CONFIGURATIONS = {
-        "model_with_asset": {"asset": "test/yolo:1"}
+        "model_with_asset": {"asset_path": "test/yolo:1"}
     }
 ```
 

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -226,8 +226,8 @@ class ModelLibrary:
         }
 
         self.models[model_name] = configuration.model_type(
-            asset_path=self.assets_info[configuration.asset]["path"]
-            if configuration.asset
+            asset_path=self.assets_info[configuration.asset_path]["path"]
+            if configuration.asset_path
             else "",
             model_dependencies=model_dependencies,
             service_settings=self.settings,
@@ -248,7 +248,7 @@ class ModelLibrary:
         for dep_name in configuration.model_dependencies.values():
             self._resolve_assets(dep_name)
 
-        if not configuration.asset:
+        if not configuration.asset_path:
             # If the model has no asset to load
             return
 
@@ -259,11 +259,11 @@ class ModelLibrary:
 
         # If the asset is overriden in the model_settings
         if "asset_path" in model_settings:
-            self.assets_info[configuration.asset] = {
+            self.assets_info[configuration.asset_path] = {
                 "path": model_settings.pop("asset_path")
             }
 
-        asset_spec = AssetSpec.from_string(configuration.asset)
+        asset_spec = AssetSpec.from_string(configuration.asset_path)
 
         # If the model's asset is overriden with environment variables
         venv = "MODELKIT_{}_FILE".format(
@@ -276,7 +276,7 @@ class ModelLibrary:
                 asset_name=asset_spec.name,
                 path=local_file,
             )
-            self.assets_info[configuration.asset] = {"path": local_file}
+            self.assets_info[configuration.asset_path] = {"path": local_file}
 
         # The assets should be retrieved
         # possibly override version
@@ -290,7 +290,7 @@ class ModelLibrary:
         try:
             if self.override_assets_manager:
                 self.assets_info[
-                    configuration.asset
+                    configuration.asset_path
                 ] = self.override_assets_manager.fetch_asset(
                     spec=AssetSpec(name=asset_spec.name, sub_part=asset_spec.sub_part),
                     return_info=True,
@@ -304,8 +304,8 @@ class ModelLibrary:
                 "Asset not found in overriden prefix",
                 name=asset_spec.name,
             )
-        if configuration.asset not in self.assets_info:
-            self.assets_info[configuration.asset] = self.asset_manager.fetch_asset(
+        if configuration.asset_path not in self.assets_info:
+            self.assets_info[configuration.asset_path] = self.asset_manager.fetch_asset(
                 asset_spec, return_info=True
             )
 

--- a/modelkit/core/model_configuration.py
+++ b/modelkit/core/model_configuration.py
@@ -13,7 +13,7 @@ from modelkit.core.model import Asset
 
 class ModelConfiguration(pydantic.BaseSettings):
     model_type: Type[Asset]
-    asset: Optional[str]
+    asset_path: Optional[str]
     model_settings: Optional[Dict[str, Any]] = {}
     model_dependencies: Optional[Dict[str, str]]
 
@@ -102,8 +102,8 @@ def list_assets(
     assets: Set[str] = set()
     for model in required_models or merged_configuration.keys():
         model_configuration = merged_configuration[model]
-        if model_configuration.asset:
-            assets.add(model_configuration.asset)
+        if model_configuration.asset_path:
+            assets.add(model_configuration.asset_path)
         if model_configuration.model_dependencies:
             assets |= list_assets(
                 configuration=merged_configuration,

--- a/modelkit/utils/tensorflow.py
+++ b/modelkit/utils/tensorflow.py
@@ -34,9 +34,9 @@ def deploy_tf_models(svc, mode, config_name="config", verbose=False):
         if not issubclass(model_configuration.model_type, TensorflowModel):
             logger.info(f"Skipping non TF model `{model_name}`")
             continue
-        if not model_configuration.asset:
+        if not model_configuration.asset_path:
             raise ValueError(f"TensorFlow model `{model_name}` does not have an asset")
-        spec = AssetSpec.from_string(model_configuration.asset)
+        spec = AssetSpec.from_string(model_configuration.asset_path)
         if mode == "local-docker":
             model_paths[model_name] = os.path.join(
                 "/config",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,7 +37,7 @@ def test_override_asset():
     config = {
         "some_asset": ModelConfiguration(
             model_type=TestModel,
-            asset="asset/that/does/not/exist",
+            asset_path="asset/that/does/not/exist",
             model_dependencies={"dep_model"},
         ),
         "dep_model": ModelConfiguration(model_type=TestDepModel),
@@ -63,7 +63,7 @@ def test_override_asset():
     # Finally, it is possible to also specify
     # an asset for the dependent model
     config["dep_model"] = ModelConfiguration(
-        model_type=TestDepModel, asset="cat/someasset"
+        model_type=TestDepModel, asset_path="cat/someasset"
     )
     prediction_service = ModelLibrary(
         required_models={
@@ -130,50 +130,50 @@ def test__configurations_from_objects():
 
 def test_configure_override():
     class SomeModel(Model):
-        CONFIGURATIONS = {"yolo": {"asset": "ok/boomer"}, "les simpsons": {}}
+        CONFIGURATIONS = {"yolo": {"asset_path": "ok/boomer"}, "les simpsons": {}}
 
     class SomeOtherModel(Model):
         pass
 
     configurations = configure(models=SomeModel)
     assert configurations["yolo"].model_type == SomeModel
-    assert configurations["yolo"].asset == "ok/boomer"
+    assert configurations["yolo"].asset_path == "ok/boomer"
     assert configurations["les simpsons"].model_type == SomeModel
-    assert configurations["les simpsons"].asset is None
+    assert configurations["les simpsons"].asset_path is None
 
     configurations = configure(
         models=SomeModel,
         configuration={"somethingelse": ModelConfiguration(model_type=SomeOtherModel)},
     )
     assert configurations["yolo"].model_type == SomeModel
-    assert configurations["yolo"].asset == "ok/boomer"
+    assert configurations["yolo"].asset_path == "ok/boomer"
     assert configurations["les simpsons"].model_type == SomeModel
-    assert configurations["les simpsons"].asset is None
+    assert configurations["les simpsons"].asset_path is None
     assert configurations["somethingelse"].model_type == SomeOtherModel
-    assert configurations["somethingelse"].asset is None
+    assert configurations["somethingelse"].asset_path is None
 
     configurations = configure(
         models=SomeModel,
         configuration={"yolo": ModelConfiguration(model_type=SomeOtherModel)},
     )
     assert configurations["yolo"].model_type == SomeOtherModel
-    assert configurations["yolo"].asset is None
+    assert configurations["yolo"].asset_path is None
 
     configurations = configure(
         models=SomeModel,
-        configuration={"yolo": {"asset": "something/else"}},
+        configuration={"yolo": {"asset_path": "something/else"}},
     )
     assert configurations["yolo"].model_type == SomeModel
-    assert configurations["yolo"].asset == "something/else"
+    assert configurations["yolo"].asset_path == "something/else"
 
     configurations = configure(
         models=SomeModel,
         configuration={"yolo2": {"model_type": SomeOtherModel}},
     )
     assert configurations["yolo"].model_type == SomeModel
-    assert configurations["yolo"].asset == "ok/boomer"
+    assert configurations["yolo"].asset_path == "ok/boomer"
     assert configurations["yolo2"].model_type == SomeOtherModel
-    assert configurations["yolo2"].asset is None
+    assert configurations["yolo2"].asset_path is None
 
 
 def test_modellibrary_required_models():
@@ -250,21 +250,21 @@ def test_dependencies_not_in_init():
 
 def test_list_assets():
     class SomeModel(Asset):
-        CONFIGURATIONS = {"model0": {"asset": "some/asset"}}
+        CONFIGURATIONS = {"model0": {"asset_path": "some/asset"}}
 
     class SomeOtherModel(Asset):
-        CONFIGURATIONS = {"model1": {"asset": "some/asset"}}
+        CONFIGURATIONS = {"model1": {"asset_path": "some/asset"}}
 
     assert {"some/asset"} == list_assets(SomeModel)
     assert {"some/asset"} == list_assets([SomeModel, SomeOtherModel])
     assert {"some/asset", "some/otherasset"} == list_assets(
         [SomeModel, SomeOtherModel],
-        configuration={"model1": {"asset": "some/otherasset"}},
+        configuration={"model1": {"asset_path": "some/otherasset"}},
     )
     assert {"some/asset"} == list_assets(
         [SomeModel, SomeOtherModel],
         required_models=["model0"],
-        configuration={"model1": {"asset": "some/otherasset"}},
+        configuration={"model1": {"asset_path": "some/otherasset"}},
     )
 
 
@@ -284,7 +284,7 @@ def assetsmanager_settings(working_dir):
 
 def test_download_assets_version(assetsmanager_settings):
     class SomeModel(Asset):
-        CONFIGURATIONS = {"model0": {"asset": "category/asset:0.0"}}
+        CONFIGURATIONS = {"model0": {"asset_path": "category/asset:0.0"}}
 
     model_assets, assets_info = download_assets(
         assetsmanager_settings=assetsmanager_settings,
@@ -294,7 +294,7 @@ def test_download_assets_version(assetsmanager_settings):
     assert assets_info["category/asset:0.0"]["version"] == "0.0"
 
     class SomeModel(Asset):
-        CONFIGURATIONS = {"model0": {"asset": "category/asset"}}
+        CONFIGURATIONS = {"model0": {"asset_path": "category/asset"}}
 
     model_assets, assets_info = download_assets(
         assetsmanager_settings=assetsmanager_settings,
@@ -304,7 +304,7 @@ def test_download_assets_version(assetsmanager_settings):
     assert assets_info["category/asset"]["version"] == "1.0"
 
     class SomeModel(Asset):
-        CONFIGURATIONS = {"model0": {"asset": "category/asset:0"}}
+        CONFIGURATIONS = {"model0": {"asset_path": "category/asset:0"}}
 
     model_assets, assets_info = download_assets(
         assetsmanager_settings=assetsmanager_settings,
@@ -316,11 +316,11 @@ def test_download_assets_version(assetsmanager_settings):
 
 def test_download_assets_dependencies(assetsmanager_settings):
     class SomeModel(Asset):
-        CONFIGURATIONS = {"model0": {"asset": "category/asset"}}
+        CONFIGURATIONS = {"model0": {"asset_path": "category/asset"}}
 
     class SomeOtherModel(Asset):
         CONFIGURATIONS = {
-            "model1": {"asset": "category/asset:0", "model_dependencies": {"model0"}}
+            "model1": {"asset_path": "category/asset:0", "model_dependencies": {"model0"}}
         }
 
     model_assets, assets_info = download_assets(
@@ -392,7 +392,7 @@ def test_environment_asset_load(monkeypatch, assetsmanager_settings):
         required_models=["some_asset"],
         configuration={
             "some_asset": ModelConfiguration(
-                model_type=TestModel, asset="tests/test_asset"
+                model_type=TestModel, asset_path="tests/test_asset"
             )
         },
         assetsmanager_settings=assetsmanager_settings,
@@ -443,10 +443,10 @@ def test_override_prefix(assetsmanager_settings):
         required_models=["my_model", "my_override_model"],
         configuration={
             "my_model": ModelConfiguration(
-                model_type=TestModel, asset="category/asset"
+                model_type=TestModel, asset_path="category/asset"
             ),
             "my_override_model": ModelConfiguration(
-                model_type=TestModel, asset="category/override-asset"
+                model_type=TestModel, asset_path="category/override-asset"
             ),
         },
         assetsmanager_settings=assetsmanager_settings,
@@ -462,10 +462,10 @@ def test_override_prefix(assetsmanager_settings):
         required_models=["my_model", "my_override_model"],
         configuration={
             "my_model": ModelConfiguration(
-                model_type=TestModel, asset="category/asset"
+                model_type=TestModel, asset_path="category/asset"
             ),
             "my_override_model": ModelConfiguration(
-                model_type=TestModel, asset="category/override-asset"
+                model_type=TestModel, asset_path="category/override-asset"
             ),
         },
         settings={"override_storage_prefix": "override-assets-prefix"},

--- a/tests/test_tf_model.py
+++ b/tests/test_tf_model.py
@@ -15,7 +15,7 @@ from tests.conftest import skip_unless
 class DummyTFModel(TensorflowModel):
     CONFIGURATIONS = {
         "dummy_tf_model": {
-            "asset": "dummy_tf_model:0.0",
+            "asset_path": "dummy_tf_model:0.0",
             "model_settings": {
                 "output_dtypes": {"lambda": np.float32},
                 "output_tensor_mapping": {"lambda": "nothing"},

--- a/tests/testdata/library_describe.txt
+++ b/tests/testdata/library_describe.txt
@@ -15,12 +15,12 @@ Settings
 Configuration                                                                   
 ├── some_complex_model_a : ModelConfiguration                                   
 │   ├── model_type : Type[Asset] = SomeComplexValidatedModelA type              
-│   ├── asset : str = None                                                      
+│   ├── asset_path : str = None                                                 
 │   ├── model_settings : Dict[str,typing.Any] = {}                              
 │   └── model_dependencies : Dict[str,str] = {}                                 
 └── some_model_a : ModelConfiguration                                           
     ├── model_type : Type[Asset] = SomeSimpleValidatedModelA type               
-    ├── asset : str = None                                                      
+    ├── asset_path : str = None                                                 
     ├── model_settings : Dict[str,typing.Any] = {}                              
     └── model_dependencies : Dict[str,str] = {}                                 
 Assets                                                                          


### PR DESCRIPTION
Replace the confusing `asset` attribute by `asset_path` to be consistent all over modelkit.