### PR TITLE
Async: fix async-sync-async in an async context

### DIFF
--- a/docs/library/developing_modelkit.md
+++ b/docs/library/developing_modelkit.md
@@ -27,7 +27,7 @@ This simple model class will always return `"something"`:
 from modelkit.core.model import Model
 
 class SimpleModel(Model):
-    async def _predict(self, item) -> str:
+    def _predict(self, item) -> str:
         return "something"
 ```
 
@@ -51,12 +51,9 @@ class SimpleModel(Model):
     CONFIGURATIONS = {
         "simple": {}
     }
-    async def _predict(self, item):
+    def _predict(self, item):
         return "something"
 ```
-
-!!! important
-    You have to `async def` when implementing `_predict` and `_predict_batch`, even if the function is synchronous.
 
 Right now, we have only given it a name `"simple"` which makes the model available to other models via the `ModelLibrary`.
 
@@ -86,7 +83,7 @@ class SimpleModel(Model):
         "simple": {"model_settings": {"value" : "something"}},
         "simple2": {"model_settings": {"value" : "something2"}}
     }
-    async def _predict(self, item):
+    def _predict(self, item):
         return self.model_settings["value"]
 ```
 
@@ -138,7 +135,7 @@ class ModelWithAsset(Model):
         with bz2.BZ2File(self.asset_path, "rb") as f:
             self.data_structure = pickle.load(f) # loads {"response": "YOLO les simpsons"}
 
-    async def _predict(self, item: Dict[str, str], **kwargs) -> float:
+    def _predict(self, item: Dict[str, str], **kwargs) -> float:
         return self.data_structure["response"] # returns "YOLO les simpsons"
 ```
 
@@ -168,7 +165,7 @@ class SomeModel(Model):
 The `ModelLibrary` ensures that whenever `_load` or the `_predict_*` function are called, these models are loaded and present in the `model_dependencies` dictionary:
 
 ```python
-async def _predict(self, item):
+def _predict(self, item):
     cleaned = self.models_dependencies["sentence_piece_cleaner"](item["text"])
     ...
 
@@ -256,7 +253,7 @@ class ReturnModel(pydantic.BaseModel):
     x: int
 
 class SomeValidatedModel(Model[ItemModel, ReturnModel]):
-    async def _predict(self, item):
+    def _predict(self, item):
         # item is guaranteed to be an instance of `ItemModel` even if we feed a dictionary item
         return {"x": item.x}
 
@@ -275,7 +272,7 @@ y : List[ReturnModel] = m([{"x": 1}, {"x": 2}])
 ```python
 
 class Identity(Model)
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
     
 m = Identity()
@@ -290,7 +287,7 @@ batches of inputs at once. In this case, one can override `_predict_batch` inste
 ```python
 
 class IdentityBatched(Model)
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
     
 m_batched = IdentityBatched()
@@ -324,7 +321,7 @@ class IdentityBatched(Model):
             }
         }
     }
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 ```
 

--- a/docs/library/overview.md
+++ b/docs/library/overview.md
@@ -18,7 +18,7 @@ The normal way to use `modelkit` models is by instantiating a `ModelLibrary` wit
 from modelkit import ModelLibrary, Model
 
 class MyModel(Model):
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 
 

--- a/docs/library/special/distant.md
+++ b/docs/library/special/distant.md
@@ -42,8 +42,7 @@ Several parameters control how `modelkit` requests predictions from TF serving.
 -   `enable_tf_serving`: Controls wether to use TF serving or use TF locally as a lib
 -   `tf_serving_host`: Host to connect to to request TF predictions
 -   `tf_serving_port`: Port to connect to to request TF predictions
--   `tf_serving_mode`: Can be `grpc` (with `grpc`) or `rest` (with `requests`)
-    or `rest-async` (with `aiohttp`)
+-   `tf_serving_mode`: Can be `grpc` (with `grpc`) or `rest` (with `requests` for `TensorflowModel`, or with `aiohttp` for `AsyncTensorflowModel`)
 -   `tf_serving_timeout_s`: timeout to wait for the first TF serving response
 
 All of these parameters can be set programmatically (and passed to the `ModelLibrary`'s settings),
@@ -66,7 +65,7 @@ tensors predicted by the TF model:
 Typically, inside a `_predict_batch`, one would do something like:
 
 ```python
-async def _predict_batch(self, items):
+def _predict_batch(self, items):
     data = await self._tensorflow_predict(
             {
                 key: np.stack([item[key] for item in items], axis=0)
@@ -105,7 +104,7 @@ In this case we use the following pattern, wherein we leverage the method
 `TensorflowModel._rebuild_predictions_with_mask`:
 
 ```python
-async def _predict_batch(
+def _predict_batch(
     self, items: List[Dict[str, str]], **kwargs
 ) -> List[Tuple[np.ndarray, List[str]]]:
     treated_items = self.treat(items)

--- a/docs/library/special/tensorflow.md
+++ b/docs/library/special/tensorflow.md
@@ -19,7 +19,7 @@ At initialization time, a `TensorflowModel` has to be provided with definitions 
 Typically, inside a `_predict_batch`, one would do something like:
 
 ```python
-async def _predict_batch(self, items):
+def _predict_batch(self, items):
     data = await self._tensorflow_predict(
             {
                 key: np.stack([item[key] for item in items], axis=0)
@@ -54,7 +54,7 @@ Oftentimes we manipulate the item before feeding it to TF, e.g. doing text clean
 In this case we use the following pattern, wherein we leverage the method `TensorflowModel._rebuild_predictions_with_mask`:
 
 ```python
-async def _predict_batch(
+def _predict_batch(
     self, items: List[Dict[str, str]], **kwargs
 ) -> List[Tuple[np.ndarray, List[str]]]:
     treated_items = self.treat(items)
@@ -123,7 +123,7 @@ Several environment variables control how `modelkit` requests predictions from T
 - `ENABLE_TF_SERVING`: Controls whether to use TF serving or use TF locally as a lib
 - `TF_SERVING_HOST`: Host to connect to to request TF predictions
 - `TF_SERVING_PORT`: Port to connect to to request TF predictions
-- `TF_SERVING_MODE`: Can be `grpc` (with `grpc`) or `rest` (with `requests`) or `rest-async` (with `aiohttp`)
+- `TF_SERVING_MODE`: Can be `grpc` (with `grpc`) or `rest` (with `requests` for `TensorflowModel`, or with `aiohttp` for `AsyncTensorflowModel`)
 - `TF_SERVING_TIMEOUT_S`: timeout to wait for the first TF serving response
 
 All of these parameters can be set programmatically (and passed to the `ModelLibrary`'s settings):

--- a/docs/library/testing.md
+++ b/docs/library/testing.md
@@ -38,7 +38,7 @@ class TestableModel(Model[ModelItemType, ModelItemType]):
         ]
     }
 
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 
 ```

--- a/docs/library/using_models.md
+++ b/docs/library/using_models.md
@@ -9,7 +9,7 @@ The normal way to use `modelkit` models is by instantiating a `ModelLibrary` wit
 from modelkit import ModelLibrary, Model
 
 class MyModel(Model):
-    async def _predict(self, item):
+    def _predict(self, item):
         return item
 
 

--- a/modelkit/core/models/tensorflow_model.py
+++ b/modelkit/core/models/tensorflow_model.py
@@ -323,7 +323,7 @@ def connect_tf_serving(model_name, host, port, mode):
         if version != 1:
             raise TFServingError(f"Bad model version: {version}!=1")
         return stub
-    elif mode in {"rest", "rest-async"}:
+    elif mode in {"rest", "rest"}:
         response = requests.get(f"http://{host}:{port}/v1/models/{model_name}")
         if response.status_code != 200:
             raise TFServingError("Error connecting to TF serving")

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,8 @@ pydantic
 python-dateutil
 redis
 rich
+sniffio
+asgiref
 structlog
 tenacity
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@
 
 aiohttp==3.7.3
     # via -r requirements.in
+asgiref==3.3.4
+    # via -r requirements.in
 async-timeout==3.0.1
     # via aiohttp
 attrs==20.3.0
@@ -116,6 +118,8 @@ six==1.15.0
     #   python-dateutil
     #   structlog
     #   tenacity
+sniffio==1.2.0
+    # via -r requirements.in
 structlog==20.1.0
     # via -r requirements.in
 tenacity==6.3.0
@@ -126,6 +130,7 @@ typing-extensions==3.7.4.3 ; python_version < "3.8"
     # via
     #   -r requirements.in
     #   aiohttp
+    #   asgiref
     #   importlib-metadata
     #   rich
     #   yarl

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ include_package_data = True
 packages = find:
 install_requires = 
 	aiohttp
+	asgiref
 	click
 	filelock
 	humanize
@@ -24,6 +25,7 @@ install_requires =
 	pydantic
 	python-dateutil
 	redis
+	sniffio
 	structlog
 	tenacity
 	tqdm

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -4,7 +4,7 @@ import pydantic
 import pytest
 
 from modelkit.core.library import ModelLibrary
-from modelkit.core.model import AsyncModel, Model
+from modelkit.core.model import AsyncModel, Model, WrappedAsyncModel
 
 
 def test_compose_sync_async():
@@ -23,6 +23,7 @@ def test_compose_sync_async():
 
     library = ModelLibrary(models=[SomeAsyncModel, ComposedModel])
     m = library.get("composed_model")
+    assert isinstance(m.model_dependencies["async_model"], WrappedAsyncModel)
     assert m.predict({"hello": "world"}) == {"hello": "world"}
 
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,7 +12,7 @@ def test_compose_sync_async():
         CONFIGURATIONS = {"async_model": {}}
 
         async def _predict(self, item, **kwargs):
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             return item
 
     class ComposedModel(Model):
@@ -33,7 +33,7 @@ async def test_compose_async_sync_async(event_loop):
         CONFIGURATIONS = {"async_model": {}}
 
         async def _predict(self, item):
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             return item
 
     class ComposedModel(Model):
@@ -48,7 +48,7 @@ async def test_compose_async_sync_async(event_loop):
         }
 
         async def _predict(self, item):
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             return await self.model_dependencies["composed_model"].predict(item)
 
     library = ModelLibrary(
@@ -72,7 +72,7 @@ async def _do_async(model, item, expected=None):
 async def test_async_predict(event_loop):
     class SomeModel(AsyncModel):
         async def _predict(self, item, **kwargs):
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             return item
 
     m = SomeModel()
@@ -88,7 +88,7 @@ async def test_async_predict(event_loop):
 
     class SomeModel(AsyncModel[Item, Item]):
         async def _predict(self, item, **kwargs):
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             return item
 
     m = SomeModel()


### PR DESCRIPTION
With the previous PR it is not possible to have an async model having a sync model as a dependency that runs an async model. This PR makes it possible.

The problem arises because `asyncio.run` closes the running loop. I go around this by using asgiref.sync.AsyncToSync (https://github.com/django/asgiref), and sniffio (https://sniffio.readthedocs.io/en/latest/#) to detect the context (sync vs async).

This means that, in particular, the async model needs to await the non-async-defined `predict` of its sync dependent model. Which makes sense.

I also fix the documentation