### PR TITLE
Fix allowed item types

### DIFF
--- a/modelkit/core/types.py
+++ b/modelkit/core/types.py
@@ -1,24 +1,9 @@
-from typing import (
-    Any,
-    ByteString,
-    Dict,
-    Generic,
-    List,
-    Mapping,
-    Optional,
-    Set,
-    TypeVar,
-    Union,
-)
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 import pydantic
 import pydantic.generics
 
-ALLOWED_ITEM_TYPES = Union[
-    str, int, float, Mapping, Set, ByteString, pydantic.BaseModel
-]
-
-ItemType = TypeVar("ItemType", bound=ALLOWED_ITEM_TYPES)
+ItemType = TypeVar("ItemType")
 ReturnType = TypeVar("ReturnType")
 
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -9,9 +9,9 @@ from tests import TEST_DIR
 def _mypy_check_file(fn, raises):
     result = mypy.api.run([os.path.join(TEST_DIR, "testdata", "typing", fn)])
     if raises:
-        assert result[2] != 0
+        assert result[2] != 0, result
     else:
-        assert result[2] == 0
+        assert result[2] == 0, result
 
 
 TEST_CASES = [
@@ -19,6 +19,7 @@ TEST_CASES = [
     ("predict_bad.py", True),
     ("predict_pydantic_ok.py", False),
     ("predict_pydantic_bad.py", True),
+    ("predict_list.py", False),
 ]
 
 

--- a/tests/testdata/typing/predict_list.py
+++ b/tests/testdata/typing/predict_list.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from modelkit.core.model import Model
+
+
+class M(Model[List[int], int]):
+    def _predict(self, item):
+        return sum(item)


### PR DESCRIPTION
In previous versions, `predict` could do either `Item->Result` or `List[Item]->List[Result]`.

This imposed a limitation on the `Item` that could no be lists, in order to be able to chose between either mode when predicting.

Since this is now disallowed, we can now use arbitrary types as `Item` of a `Model`.
