### PR TITLE
Predict evaluation

### DIFF
--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -446,7 +446,7 @@ class Model(BaseModel[ItemType, ReturnType]):
     def predict_batch(
         self,
         items: List[ItemType],
-        callback: Callable = None,
+        _callback: Callable = None,
         batch_size: int = None,
         _force_compute: bool = False,
         **kwargs,
@@ -461,8 +461,8 @@ class Model(BaseModel[ItemType, ReturnType]):
                 )
             )
             predictions.extend(current_predictions)
-            if callback:
-                callback(step, batch, current_predictions)
+            if _callback:
+                _callback(step, batch, current_predictions)
         return predictions
 
     def _predict_single_batch_gen(
@@ -564,7 +564,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
     async def predict_batch(
         self,
         items: List[ItemType],
-        callback: Callable = None,
+        _callback: Callable = None,
         batch_size: int = None,
         _force_compute: bool = False,
         _return_info: bool = False,
@@ -591,7 +591,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
             computed_results = await self._predict_by_batch(
                 [item[2] for item in to_compute],
                 batch_size=batch_size or self.batch_size,
-                callback=callback,
+                _callback=_callback,
                 **kwargs,
             )
             for ((kitem, key, _), result) in zip(to_compute, computed_results):
@@ -614,7 +614,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
             results = await self._predict_by_batch(
                 items,
                 batch_size=batch_size or self.batch_size,
-                callback=callback,
+                _callback=_callback,
                 **kwargs,
             )
 
@@ -623,15 +623,15 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
         )
 
     async def _predict_by_batch(
-        self, items: List[ItemType], batch_size=64, callback=None, **kwargs
+        self, items: List[ItemType], batch_size=64, _callback=None, **kwargs
     ) -> List[ReturnType]:
         predictions = []
         for step in range(0, len(items), batch_size):
             batch = items[step : step + batch_size]
             current_predictions = await self._predict_batch(batch, **kwargs)
             predictions.extend(current_predictions)
-            if callback:
-                callback(step, batch, current_predictions)
+            if _callback:
+                _callback(step, batch, current_predictions)
         return predictions
 
     async def _predict_batch(self, items: List[ItemType], **kwargs) -> List[ReturnType]:

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -441,19 +441,15 @@ class Model(BaseModel[ItemType, ReturnType]):
         _force_compute: bool = False,
         **kwargs,
     ) -> List[ReturnType]:
-        batch_size = batch_size or self.batch_size
-        predictions = []
-        for step in range(0, len(items), batch_size):
-            batch = items[step : step + batch_size]
-            current_predictions = list(
-                self._predict_single_batch_gen(
-                    step, batch, _force_compute=_force_compute, **kwargs
-                )
+        return list(
+            self.predict_gen(
+                iter(items),
+                _callback=_callback,
+                batch_size=batch_size,
+                _force_compute=_force_compute,
+                **kwargs,
             )
-            predictions.extend(current_predictions)
-            if _callback:
-                _callback(step, batch, current_predictions)
-        return predictions
+        )
 
     def _predict_single_batch_gen(
         self,

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -50,7 +50,7 @@ def test_callback_batch_process(items, batch_size, expected_steps, monkeypatch):
     def func(items):
         return [item + 1 for item in items]
 
-    def callback(batch_step, batch_items, batch_results):
+    def _callback(batch_step, batch_items, batch_results):
         nonlocal steps
         nonlocal items
         assert items[batch_step : batch_step + batch_size] == batch_items
@@ -58,7 +58,7 @@ def test_callback_batch_process(items, batch_size, expected_steps, monkeypatch):
 
     m = Model()
     monkeypatch.setattr(m, "_predict_batch", func)
-    m.predict_batch(items, batch_size=batch_size, callback=callback)
+    m.predict_batch(items, batch_size=batch_size, _callback=_callback)
     assert steps == expected_steps
 
 

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -59,6 +59,7 @@ def test_callback_batch_process(items, batch_size, expected_steps, monkeypatch):
     m = Model()
     monkeypatch.setattr(m, "_predict_batch", func)
     m.predict_batch(items, batch_size=batch_size, _callback=_callback)
+    m.predict_gen(items, batch_size=batch_size, _callback=_callback)
     assert steps == expected_steps
 
 


### PR DESCRIPTION
The `predict`/`predict_batch`/`predict_gen` is quite redundant, and this PR is an attempt to fix this.

Using `predict_gen` for `predict` is straightfoward, I convert `item` into an iterator of `items` with `iter((item,))` which seems the fastest, and `next` to obtain the prediction.

For `predict_batch` it is slightly more complicated because I had not implemented the `callback` logic in the `predict_gen`. 
In a first commit, I rename `callback=` to `_callback=` in the arguments. Then I implement it in `predict_gen` (and add the test case). Finally, I use `predict_gen` for `predict_batch`.

Note that, at the moment, none of this is done for `AsyncModel`, because I first need to implement the `async` version of `predict_gen`. I will do so once I sort out the caching, it will be more straightforward.