### PR TITLE
Caching

### DIFF
--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -22,9 +22,10 @@ from modelkit.assets.settings import AssetSpec
 from modelkit.core.model import Model
 from modelkit.core.model_configuration import ModelConfiguration, configure, list_assets
 from modelkit.core.settings import LibrarySettings
+from modelkit.utils.cache import RedisCache
 from modelkit.utils.memory import PerformanceTracker
 from modelkit.utils.pretty import describe
-from modelkit.utils.redis import RedisCacheException, check_redis
+from modelkit.utils.redis import RedisCacheException
 
 logger = get_logger(__name__)
 
@@ -83,10 +84,10 @@ class ModelLibrary:
         self.redis_cache = None
         if self.settings.redis.enable:
             try:
-                self.redis_cache = check_redis(
+                self.redis_cache = RedisCache(
                     self.settings.redis.host, self.settings.redis.port
                 )
-            except (AssertionError, redis.ConnectionError):
+            except (ConnectionError, redis.ConnectionError):
                 logger.error(
                     "Cannot ping redis instance",
                     cache_host=self.settings.redis.host,

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -81,10 +81,10 @@ class ModelLibrary:
         if isinstance(self.required_models, list):
             self.required_models = {r: {} for r in self.required_models}
 
-        self.redis_cache = None
+        self.cache = None
         if self.settings.redis.enable:
             try:
-                self.redis_cache = RedisCache(
+                self.cache = RedisCache(
                     self.settings.redis.host, self.settings.redis.port
                 )
             except (ConnectionError, redis.ConnectionError):
@@ -234,7 +234,7 @@ class ModelLibrary:
             service_settings=self.settings,
             model_settings=model_settings or {},
             configuration_key=model_name,
-            redis_cache=self.redis_cache,
+            cache=self.cache,
         )
         if not self.settings.lazy_loading:
             self.models[model_name].load()

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -564,93 +564,81 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
         self,
         items: Iterator[ItemType],
         batch_size: int = None,
-        _force_compute: bool = False,
         _callback: Callable = None,
+        _force_compute: bool = False,
         **kwargs,
     ) -> AsyncIterator[ReturnType]:
         batch_size = batch_size or self.batch_size
+
         batch: List[ItemType] = []
+        cached_results: List[Union[ItemType, CachedStatus]] = []
         step = 0
         while True:
             try:
                 if len(batch) == batch_size:
-                    async for r in self._predict_single_batch_gen(
+                    async for r in self._predict_from_batch_and_cache(
                         step,
                         batch,
-                        _force_compute=_force_compute,
+                        cached_results,
                         _callback=_callback,
                         **kwargs,
                     ):
                         yield r
-                    step += batch_size
+
                     batch = []
+                    cached_results = []
+                    step += batch_size
                 else:
-                    batch.append(next(items))
+                    current_item = self._validate(
+                        next(items), self._item_model, ItemValidationException
+                    )
+                    if (
+                        self.redis_cache
+                        and self.model_settings.get("cache_predictions")
+                        and not _force_compute
+                    ):
+                        cached_results.append(
+                            self.redis_cache.get(current_item, CachedStatus.NOT_CACHED)
+                        )
+                    else:
+                        cached_results.append(CachedStatus.NOT_CACHED)
+                    batch.append(current_item)
             except StopIteration:
                 break
+
         if batch:
-            async for r in self._predict_single_batch_gen(
+            async for r in self._predict_from_batch_and_cache(
                 step,
                 batch,
-                _force_compute=_force_compute,
+                cached_results,
                 _callback=_callback,
                 **kwargs,
             ):
                 yield r
 
-    async def _predict_single_batch_gen(
-        self,
-        _step: int,
-        items: List[ItemType],
-        _force_compute: bool = False,
-        _callback: Callable = None,
-        **kwargs,
+    async def _predict_from_batch_and_cache(
+        self, _step: int, batch, cached_results, _callback: Callable = None, **kwargs
     ) -> AsyncIterator[ReturnType]:
-        items = [
-            self._validate(i, self._item_model, ItemValidationException) for i in items
-        ]
-        if self.redis_cache and self.model_settings.get("cache_predictions"):
-            # In the case where cache is activated, sieve through
-            # individual items
-            results = []
-            to_compute = []
-            for kitem, item in enumerate(items):
-                key = self.item_cache_key(item, kwargs)
-                if not _force_compute and self.redis_cache.exists(key):
-                    # We trust the data coming from Redis as it's a local cache
-                    unpickled = pickle.loads(self.redis_cache.get(key))  # nosec
-                    results.append(unpickled)
-                else:
-                    results.append(None)
-                    to_compute.append((kitem, key, item))
-            computed_results = await self._predict_batch(
-                [item[2] for item in to_compute],
-                **kwargs,
-            )
-            for ((kitem, key, _), result) in zip(to_compute, computed_results):
-                self.redis_cache.set(key, pickle.dumps(result))
-                results[kitem] = result
-            logger.debug(
-                "Caching digest",
-                recomputed=len(computed_results),
-                from_cache=(len(results) - len(computed_results)),
-                model=self.configuration_key,
-            )
-        else:
-            # general case: items is a list of items to treat
-            # if there are multiple examples but no batching
-            # or if there are multiple examples and batching
-            results = [
-                self._validate(r, self._return_model, ReturnValueValidationException)
-                for r in await self._predict_batch(
-                    items,
-                    **kwargs,
+        predictions = await self._predict_batch(batch, **kwargs)
+        items_and_predictions = zip(batch, predictions)
+        for res in cached_results:
+            if res == CachedStatus.NOT_CACHED:
+                item, r = next(items_and_predictions)
+                if self.redis_cache and self.model_settings.get("cache_predictions"):
+                    self.redis_cache.setdefault(item, r)
+                yield self._validate(
+                    r,
+                    self._return_model,
+                    ReturnValueValidationException,
                 )
-            ]
+            else:
+                yield self._validate(
+                    res,
+                    self._return_model,
+                    ReturnValueValidationException,
+                )
         if _callback:
-            _callback(_step, items, results)
-        for r in results:
-            yield r
+            _callback(_step, batch, predictions)
 
 
 class WrappedAsyncModel:

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -455,12 +455,14 @@ class Model(BaseModel[ItemType, ReturnType]):
         step = 0
         while True:
             # This loops creates a list of `CacheItems` which
-            # are simple the item wrapped with information as to its
-            # status in the cache
+            # wrap the items with information as to their
+            # status within the cache.
             # Whenever `cache_items` has `batch_size` elements that need
             # to be recomputed, `_predict_cache_items` is called, which will
-            # in turn yield all results in the correct order
-            # Once we have 2 x batch_size elements available to yield
+            # in turn yield all results in the correct order.
+            # Once we have 2 x batch_size elements available from cache
+            # we yield them to avoid indefinite increase in the cache_item
+            # list size.
             try:
                 if (
                     n_items_to_compute == batch_size

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -489,10 +489,12 @@ class Model(BaseModel[ItemType, ReturnType]):
                             # When force_recomputing, we still need to get
                             # the cache key
                             cache_item = CacheItem(
-                                cache_key=self.cache.hash_key(
+                                current_item,
+                                self.cache.hash_key(
                                     self.configuration_key, current_item, kwargs
                                 ),
-                                item=current_item,
+                                None,
+                                True,
                             )
                         if cache_item.missing:
                             n_items_to_compute += 1
@@ -501,7 +503,7 @@ class Model(BaseModel[ItemType, ReturnType]):
                         cache_items.append(cache_item)
                     else:
                         # When no cache is active, all of them should be computed
-                        cache_items.append(CacheItem(item=current_item))
+                        cache_items.append(CacheItem(current_item, None, None, True))
                         n_items_to_compute += 1
             except StopIteration:
                 break
@@ -628,10 +630,12 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
                             )
                         else:
                             cache_item = CacheItem(
-                                cache_key=self.cache.hash_key(
+                                current_item,
+                                self.cache.hash_key(
                                     self.configuration_key, current_item, kwargs
                                 ),
-                                item=current_item,
+                                None,
+                                True,
                             )
                         if cache_item.missing:
                             n_items_to_compute += 1
@@ -639,7 +643,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
                             n_items_from_cache += 1
                         cache_items.append(cache_item)
                     else:
-                        cache_items.append(CacheItem(item=current_item))
+                        cache_items.append(CacheItem(current_item, None, None, True))
                         n_items_to_compute += 1
             except StopIteration:
                 break

--- a/modelkit/utils/cache.py
+++ b/modelkit/utils/cache.py
@@ -1,16 +1,21 @@
 import hashlib
 import pickle
-from typing import Any, Dict
+from typing import Any, Dict, Generic, Optional
 
 import pydantic
 
 import modelkit
+from modelkit.core.types import ItemType
 from modelkit.utils.redis import connect_redis
 
 
-class CacheItem:
+class CacheItem(Generic[ItemType]):
     def __init__(
-        self, item=None, cache_key=None, cache_value=None, missing: bool = True
+        self,
+        item: Optional[ItemType] = None,
+        cache_key: bytes = None,
+        cache_value=None,
+        missing: bool = True,
     ):
         self.item = item
         self.cache_key = cache_key
@@ -23,7 +28,7 @@ class RedisCache:
         self.redis = connect_redis(host, port)
         self.cache_keys = {}
 
-    def hash_key(self, model_key, item: Any, kwargs: Dict[str, Any]):
+    def hash_key(self, model_key: str, item: Any, kwargs: Dict[str, Any]):
         cache_key = self.cache_keys.get(model_key)
         if not cache_key:
             self.cache_keys[model_key] = (model_key + modelkit.__version__).encode()
@@ -31,7 +36,7 @@ class RedisCache:
         pickled = pickle.dumps((item, kwargs))  # nosec: only used to build a hash
         return hashlib.sha256(cache_key + pickled).digest()
 
-    def get(self, model_key, item, kwargs):
+    def get(self, model_key: str, item: Any, kwargs: Dict[str, Any]):
         cache_key = self.hash_key(model_key, item, kwargs)
         r = self.redis.get(cache_key)
         if r is None:
@@ -40,7 +45,7 @@ class RedisCache:
             cache_key=cache_key, cache_value=pickle.loads(r), missing=False
         )
 
-    def set(self, k, d):
+    def set(self, k: bytes, d: Any):
         if isinstance(d, pydantic.BaseModel):
             self.redis.set(k, pickle.dumps(d.dict()))
         else:

--- a/modelkit/utils/cache.py
+++ b/modelkit/utils/cache.py
@@ -1,0 +1,37 @@
+import hashlib
+import pickle
+from typing import Any, Dict
+
+import modelkit
+from modelkit.utils.redis import connect_redis
+
+
+class Cache:
+    def get(self, key, default):
+        pass
+
+    def setdefault(self, key, value):
+        pass
+
+
+class RedisCache:
+    def __init__(self, host, port):
+        self.redis = connect_redis(host, port)
+        self.cache_keys = {}
+
+    def hash_key(self, model_key, item: Any, kwargs: Dict[str, Any]):
+        cache_key = self.cache_keys.get(model_key)
+        if not cache_key:
+            self.cache_keys[model_key] = (model_key + modelkit.__version__).encode()
+            cache_key = self.cache_keys[model_key]
+        pickled = pickle.dumps((item, kwargs))  # nosec: only used to build a hash
+        return hashlib.sha256(cache_key + pickled).digest()
+
+    def get(self, k, d):
+        r = self.redis.get(k)
+        if r is None:
+            return d
+        return pickle.loads(r)
+
+    def setdefault(self, k, d):
+        self.redis.set(k, pickle.dumps(d))

--- a/modelkit/utils/cache.py
+++ b/modelkit/utils/cache.py
@@ -2,6 +2,8 @@ import hashlib
 import pickle
 from typing import Any, Dict
 
+import pydantic
+
 import modelkit
 from modelkit.utils.redis import connect_redis
 
@@ -39,5 +41,7 @@ class RedisCache:
         )
 
     def set(self, k, d):
-        print("set", k, d)
-        self.redis.set(k, pickle.dumps(d))
+        if isinstance(d, pydantic.BaseModel):
+            self.redis.set(k, pickle.dumps(d.dict()))
+        else:
+            self.redis.set(k, pickle.dumps(d))

--- a/modelkit/utils/redis.py
+++ b/modelkit/utils/redis.py
@@ -40,7 +40,8 @@ REDIS_RETRY_POLICY = {
 
 
 @retry(**REDIS_RETRY_POLICY)
-def check_redis(host, port):
+def connect_redis(host, port):
     redis_cache = redis.Redis(host=host, port=port)
-    assert redis_cache.ping()
+    if not redis_cache.ping():
+        raise ConnectionError("Cannot connect to redis")
     return redis_cache


### PR DESCRIPTION
In this PR I abstract an interface for caching that will later be usable to work with local python cache (e.g. LRU).

Doing so, I rework the caching such that we attempt to call `_predict_batch` with evenly sized batches. 
This is almost always the case, except when the cache contains a lot of elements. That is, going through a list of items to process, I accumulate those from the cache and those that need to be recomputed. Whenever there is exactly one full batch, it is computed and yielded (together with the possibly cached elements). On the other hand, when cached elements start to accumulate (2 x batch_size, arbitrarily), we yield them and compute the rest although the batch may not be full.

Also, I fix the caching in the case of validated models (because pydantic models cannot be cached -- they are not picklable).