### PR TITLE
caching: add native cache type, fix settings to arbitrate between each

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,9 +22,13 @@ Refer to the [AssetsManager settings documentation](assets/environment.md) for m
     - `TF_SERVING_PORT` (default: `8501`): Port of tensorflow server
     - `TF_SERVING_MODE` (default: `rest`): `rest` to use REST protocol of tensorflow server (port 8501), `grpc` to use GRPC protocol (port 8500)
     - `TF_SERVING_TIMEOUT_S` (default: `60`): Timeout duration for tensorflow server calls
-- `ENABLE_REDIS_CACHE` (default: `False) to use prediction caching
+- `CACHE_PROVIDER` (default: `None`) to use prediction caching
+  - if `CACHE_PROVIDER=redis`, use an external redis instance for caching:
     - `CACHE_HOST` (default: `localhost`)
     - `CACHE_PORT` (default: `6379`)
+  - if `CACHE_PROVIDER=native` use native caching (via [cachetools](https://cachetools.readthedocs.io/en/stable/)):
+    - `CACHE_IMPLEMENTATION` can be 
+    - `CACHE_MAX_SIZE` size of the cache
 - `modelkit_ASYNC_MODE` (default to `None`) forces the `DistantHTTPModels` to use async mode.
 
 ## New Assets Testing Environment

--- a/modelkit/core/settings.py
+++ b/modelkit/core/settings.py
@@ -1,8 +1,6 @@
-import os
 from typing import Optional, Union
 
 import pydantic
-from pydantic import root_validator
 
 
 class TFServingSettings(pydantic.BaseSettings):

--- a/modelkit/utils/cache.py
+++ b/modelkit/utils/cache.py
@@ -1,7 +1,10 @@
+import abc
 import hashlib
 import pickle
 from typing import Any, Dict, Generic, NamedTuple, Optional
 
+import cachetools
+import cachetools.keys
 import pydantic
 
 import modelkit
@@ -16,7 +19,30 @@ class CacheItem(NamedTuple, Generic[ItemType]):
     missing: bool = True
 
 
-class RedisCache:
+class Cache(abc.ABC):
+    @staticmethod
+    def from_settings(settings):
+        if settings.cache_provider == "redis":
+            return RedisCache(settings.settings.host, settings.settings.port)
+        if settings.cache_provider == "native":
+            return RedisCache(
+                settings.settings.implementation, settings.settings.maxsize
+            )
+
+    @abc.abstractmethod
+    def hash_key(self, model_key: str, item: Any, kwargs: Dict[str, Any]):
+        pass
+
+    @abc.abstractmethod
+    def get(self, model_key: str, item: Any, kwargs: Dict[str, Any]):
+        pass
+
+    @abc.abstractmethod
+    def set(self, k: bytes, d: Any):
+        pass
+
+
+class RedisCache(Cache):
     def __init__(self, host, port):
         self.redis = connect_redis(host, port)
         self.cache_keys = {}
@@ -41,3 +67,29 @@ class RedisCache:
             self.redis.set(k, pickle.dumps(d.dict()))
         else:
             self.redis.set(k, pickle.dumps(d))
+
+
+class NativeCache(Cache):
+    NATIVE_CACHE_IMPLEMENTATIONS = {
+        "LFU": cachetools.LFUCache,
+        "LRU": cachetools.LRUCache,
+    }
+
+    def __init__(self, implementation, maxsize):
+        self.cache: cachetools.Cache = self.NATIVE_CACHE_IMPLEMENTATIONS[
+            implementation
+        ](maxsize)
+
+    def hash_key(self, model_key: str, item: Any, kwargs: Dict[str, Any]):
+        pickled = pickle.dumps((item, kwargs))  # nosec: only used to build a hash
+        return cachetools.keys.hashkey((model_key, pickled))
+
+    def get(self, model_key: str, item: Any, kwargs: Dict[str, Any]):
+        cache_key = self.hash_key(model_key, item, kwargs)
+        r = self.cache.get(cache_key)
+        if r is None:
+            return CacheItem(item, cache_key, None, True)
+        return CacheItem(item, cache_key, r, False)
+
+    def set(self, k: bytes, d: Any):
+        self.cache.setdefault(k, d)

--- a/modelkit/utils/cache.py
+++ b/modelkit/utils/cache.py
@@ -20,15 +20,6 @@ class CacheItem(NamedTuple, Generic[ItemType]):
 
 
 class Cache(abc.ABC):
-    @staticmethod
-    def from_settings(settings):
-        if settings.cache_provider == "redis":
-            return RedisCache(settings.settings.host, settings.settings.port)
-        if settings.cache_provider == "native":
-            return RedisCache(
-                settings.settings.implementation, settings.settings.maxsize
-            )
-
     @abc.abstractmethod
     def hash_key(self, model_key: str, item: Any, kwargs: Dict[str, Any]):
         pass
@@ -73,6 +64,7 @@ class NativeCache(Cache):
     NATIVE_CACHE_IMPLEMENTATIONS = {
         "LFU": cachetools.LFUCache,
         "LRU": cachetools.LRUCache,
+        "RR": cachetools.RRCache,
     }
 
     def __init__(self, implementation, maxsize):

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 aiohttp
 boto3
 google-cloud-storage
+cachetools
 click
 filelock
 humanize

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,9 @@ botocore==1.19.36
     #   boto3
     #   s3transfer
 cachetools==4.2.0
-    # via google-auth
+    # via
+    #   -r requirements.in
+    #   google-auth
 certifi==2020.12.5
     # via requests
 cffi==1.14.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ packages = find:
 install_requires = 
 	aiohttp
 	asgiref
+	cachetools
 	click
 	filelock
 	humanize

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -10,10 +10,11 @@ import redis
 
 from modelkit.core.library import ModelLibrary
 from modelkit.core.model import AsyncModel, Model
+from modelkit.utils.cache import NativeCache, RedisCache
 from tests.conftest import skip_unless
 
 
-@pytest.mark.parametrize("cache_implementation", ["LFU", "LRU"])
+@pytest.mark.parametrize("cache_implementation", ["LFU", "LRU", "RR"])
 def test_native_cache(cache_implementation):
     class SomeModel(Model):
         CONFIGURATIONS = {"model": {"model_settings": {"cache_predictions": True}}}
@@ -53,6 +54,8 @@ def test_native_cache(cache_implementation):
             }
         },
     )
+
+    assert isinstance(svc.cache, NativeCache)
 
     m = svc.get("model")
     m_multi = svc.get("model_multiple")
@@ -141,6 +144,8 @@ def test_redis_cache(redis_service):
         settings={"cache": {"cache_provider": "redis"}},
     )
 
+    assert isinstance(svc.cache, RedisCache)
+
     m = svc.get("model")
     m_multi = svc.get("model_multiple")
 
@@ -203,6 +208,8 @@ async def test_redis_cache_async(redis_service, event_loop):
         models=[SomeModel, SomeModelMultiple, SomeModelValidated],
         settings={"cache": {"cache_provider": "redis"}},
     )
+
+    assert isinstance(svc.cache, RedisCache)
 
     m = svc.get("model")
     m_multi = svc.get("model_multiple")

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -13,6 +13,59 @@ from modelkit.core.model import AsyncModel, Model
 from tests.conftest import skip_unless
 
 
+@pytest.mark.parametrize("cache_implementation", ["LFU", "LRU"])
+def test_native_cache(cache_implementation):
+    class SomeModel(Model):
+        CONFIGURATIONS = {"model": {"model_settings": {"cache_predictions": True}}}
+
+        def _predict(self, item):
+            return item
+
+    class SomeModelMultiple(Model):
+        CONFIGURATIONS = {
+            "model_multiple": {"model_settings": {"cache_predictions": True}}
+        }
+
+        def _predict_batch(self, items):
+            return items
+
+    class Item(pydantic.BaseModel):
+        class SubItem(pydantic.BaseModel):
+            boomer: Union[int, List[int]]
+
+        ok: SubItem
+
+    class SomeModelValidated(Model[Item, Item]):
+        CONFIGURATIONS = {
+            "model_validated": {"model_settings": {"cache_predictions": True}}
+        }
+
+        def _predict_batch(self, items):
+            return items
+
+    svc = ModelLibrary(
+        models=[SomeModel, SomeModelMultiple, SomeModelValidated],
+        settings={
+            "cache": {
+                "cache_provider": "native",
+                "implementation": cache_implementation,
+                "maxsize": 16,
+            }
+        },
+    )
+
+    m = svc.get("model")
+    m_multi = svc.get("model_multiple")
+
+    ITEMS = [{"ok": {"boomer": 1}}, {"ok": {"boomer": [2, 2, 3]}}]
+
+    _do_model_test(m, ITEMS)
+    _do_model_test(m_multi, ITEMS)
+
+    m_validated = svc.get("model_validated")
+    _do_model_test(m_validated, ITEMS)
+
+
 @pytest.fixture()
 def redis_service(request):
     if "JENKINS_CI" in os.environ:
@@ -85,7 +138,7 @@ def test_redis_cache(redis_service):
 
     svc = ModelLibrary(
         models=[SomeModel, SomeModelMultiple, SomeModelValidated],
-        settings={"redis": {"enable": True}},
+        settings={"cache": {"cache_provider": "redis"}},
     )
 
     m = svc.get("model")
@@ -148,7 +201,7 @@ async def test_redis_cache_async(redis_service, event_loop):
 
     svc = ModelLibrary(
         models=[SomeModel, SomeModelMultiple, SomeModelValidated],
-        settings={"redis": {"enable": True}},
+        settings={"cache": {"cache_provider": "redis"}},
     )
 
     m = svc.get("model")

--- a/tests/testdata/library_describe.txt
+++ b/tests/testdata/library_describe.txt
@@ -8,10 +8,8 @@ Settings
 │   ├── mode : str = 'rest'                                                     
 │   ├── host : str = 'localhost'                                                
 │   └── port : int = 8501                                                       
-└── redis : RedisSettings                                                       
-    ├── enable : bool = False                                                   
-    ├── host : str = 'localhost'                                                
-    └── port : int = 6379                                                       
+└── cache : typing.Union[modelkit.core.settings.RedisSettings,                  
+    modelkit.core.settings.NativeCacheSettings, NoneType] = None                
 Configuration                                                                   
 ├── some_complex_model_a : ModelConfiguration                                   
 │   ├── model_type : Type[Asset] = SomeComplexValidatedModelA type              


### PR DESCRIPTION
Here I add some native caching mechanism using classes in `cachetools`. 

It's relatively straightforward since the last caching udpate which exposed an abstracted interface.