### PR TITLE
Better errors

### DIFF
--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -556,6 +556,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
     async def _predict_batch(self, items: List[ItemType], **kwargs) -> List[ReturnType]:
         return [await self._predict(p, **kwargs) for p in items]
 
+    @traceback.wrap_modelkit_exceptions_async
     async def __call__(
         self,
         item: ItemType,
@@ -564,6 +565,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
     ) -> ReturnType:
         return await self.predict(item, _force_compute=_force_compute, **kwargs)
 
+    @traceback.wrap_modelkit_exceptions_async
     async def predict(
         self,
         item: ItemType,
@@ -576,6 +578,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
             break
         return r
 
+    @traceback.wrap_modelkit_exceptions_async
     async def predict_batch(
         self,
         items: List[ItemType],
@@ -595,6 +598,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
             )
         ]
 
+    @traceback.wrap_modelkit_exceptions_gen_async
     async def predict_gen(
         self,
         items: Iterator[ItemType],

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -161,11 +161,6 @@ class ItemValidationException(ModelkitDataValidationException):
         )
 
 
-class PredictionError(Exception):
-    def __init__(self, exc):
-        self.exc = exc
-
-
 class BaseModel(Asset, Generic[ItemType, ReturnType]):
     """
     Model

--- a/modelkit/utils/traceback.py
+++ b/modelkit/utils/traceback.py
@@ -1,7 +1,9 @@
+import functools
 import inspect
 import os
 import traceback
 import types
+from typing import Any, Callable, TypeVar, cast
 
 
 def is_modelkit_internal_frame(frame: types.FrameType):
@@ -30,8 +32,11 @@ def strip_modelkit_traceback_frames(exc: BaseException):
     return exc.with_traceback(tb)
 
 
+T = TypeVar("T", bound=Callable[..., Any])
+
 # Decorators to wrap prediction methods to simplify tracebacks
-def wrap_modelkit_exceptions(func):
+def wrap_modelkit_exceptions(func: T) -> T:
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
@@ -40,10 +45,11 @@ def wrap_modelkit_exceptions(func):
                 raise strip_modelkit_traceback_frames(exc)
             raise exc
 
-    return wrapper
+    return cast(T, wrapper)
 
 
-def wrap_modelkit_exceptions_gen(func):
+def wrap_modelkit_exceptions_gen(func: T) -> T:
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             yield from func(*args, **kwargs)
@@ -52,10 +58,11 @@ def wrap_modelkit_exceptions_gen(func):
                 raise strip_modelkit_traceback_frames(exc)
             raise exc
 
-    return wrapper
+    return cast(T, wrapper)
 
 
-def wrap_modelkit_exceptions_async(func):
+def wrap_modelkit_exceptions_async(func: T) -> T:
+    @functools.wraps(func)
     async def wrapper(*args, **kwargs):
         try:
             return await func(*args, **kwargs)
@@ -64,10 +71,11 @@ def wrap_modelkit_exceptions_async(func):
                 raise strip_modelkit_traceback_frames(exc)
             raise exc
 
-    return wrapper
+    return cast(T, wrapper)
 
 
-def wrap_modelkit_exceptions_gen_async(func):
+def wrap_modelkit_exceptions_gen_async(func: T) -> T:
+    @functools.wraps(func)
     async def wrapper(*args, **kwargs):
         try:
             async for x in func(*args, **kwargs):
@@ -77,4 +85,4 @@ def wrap_modelkit_exceptions_gen_async(func):
                 raise strip_modelkit_traceback_frames(exc)
             raise exc
 
-    return wrapper
+    return cast(T, wrapper)

--- a/modelkit/utils/traceback.py
+++ b/modelkit/utils/traceback.py
@@ -1,0 +1,46 @@
+import inspect
+import os
+import traceback
+import types
+
+_MODEL_FN = os.path.join("modelkit", "core", "model.py")
+_TB_FN = os.path.join("modelkit", "utils", "traceback.py")
+
+
+def is_modelkit_internal_frame(frame: types.FrameType):
+    frame_info = inspect.getframeinfo(frame)
+    return frame_info.filename.endswith(_MODEL_FN) or frame_info.filename.endswith(
+        _TB_FN
+    )
+
+
+def strip_modelkit_traceback_frames(exc: BaseException):
+    tb = None
+    for tb_frame, _ in reversed(list(traceback.walk_tb(exc.__traceback__))):
+        if not is_modelkit_internal_frame(tb_frame):
+            tb = types.TracebackType(tb, tb_frame, tb_frame.f_lasti, tb_frame.f_lineno)
+    return exc.with_traceback(tb)
+
+
+def wrap_modelkit_exceptions(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except BaseException as exc:
+            if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
+                raise strip_modelkit_traceback_frames(exc)
+            raise exc
+
+    return wrapper
+
+
+def wrap_modelkit_exceptions_gen(func):
+    def wrapper(*args, **kwargs):
+        try:
+            yield from func(*args, **kwargs)
+        except BaseException as exc:
+            if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
+                raise strip_modelkit_traceback_frames(exc)
+            raise exc
+
+    return wrapper

--- a/modelkit/utils/traceback.py
+++ b/modelkit/utils/traceback.py
@@ -53,3 +53,28 @@ def wrap_modelkit_exceptions_gen(func):
             raise exc
 
     return wrapper
+
+
+def wrap_modelkit_exceptions_async(func):
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except BaseException as exc:
+            if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
+                raise strip_modelkit_traceback_frames(exc)
+            raise exc
+
+    return wrapper
+
+
+def wrap_modelkit_exceptions_gen_async(func):
+    async def wrapper(*args, **kwargs):
+        try:
+            async for x in func(*args, **kwargs):
+                yield x
+        except BaseException as exc:
+            if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
+                raise strip_modelkit_traceback_frames(exc)
+            raise exc
+
+    return wrapper

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,71 @@
+import pytest
+
+from modelkit.core.model import Model
+
+
+class CustomError(BaseException):
+    pass
+
+
+class OKModel(Model):
+    def _predict(self, item):
+        return self.model_dependencies["error_model"].predict(item)
+
+
+class ErrorModel(Model):
+    def _predict(self, item):
+        raise CustomError("something went wrong")
+
+
+class ErrorBatchModel(Model):
+    def _predict_batch(self, item):
+        raise CustomError("something went wrong")
+
+
+@pytest.mark.parametrize("model", [ErrorModel(), ErrorBatchModel()])
+def test_prediction_error(model):
+    with pytest.raises(CustomError) as excinfo:
+        model.predict({})
+    assert len(excinfo.traceback) <= 3
+
+    with pytest.raises(CustomError) as excinfo:
+        model.predict_batch([{}])
+    assert len(excinfo.traceback) <= 3
+
+    with pytest.raises(CustomError) as excinfo:
+        next(model.predict_gen(iter(({},))))
+    assert len(excinfo.traceback) <= 3
+
+
+def test_prediction_error_composition():
+
+    mm = OKModel(model_dependencies={"error_model": ErrorModel()})
+    mm.load()
+
+    with pytest.raises(CustomError) as excinfo:
+        mm.predict({})
+    assert len(excinfo.traceback) <= 4
+
+    with pytest.raises(CustomError) as excinfo:
+        mm.predict_batch([{}])
+    assert len(excinfo.traceback) <= 4
+
+    with pytest.raises(CustomError) as excinfo:
+        next(mm.predict_gen(iter(({},))))
+    assert len(excinfo.traceback) <= 4
+
+
+@pytest.mark.parametrize("model", [ErrorModel(), ErrorBatchModel()])
+def test_prediction_error_complex_tb(monkeypatch, model):
+    monkeypatch.setenv("ENABLE_SIMPLE_TRACEBACK", False)
+    with pytest.raises(CustomError) as excinfo:
+        model.predict({})
+    assert len(excinfo.traceback) > 3
+
+    with pytest.raises(CustomError) as excinfo:
+        model.predict_batch([{}])
+    assert len(excinfo.traceback) > 3
+
+    with pytest.raises(CustomError) as excinfo:
+        next(model.predict_gen(iter(({},))))
+    assert len(excinfo.traceback) > 3


### PR DESCRIPTION
Previously, errors raised within `Model._predict*` methods can be cryptic to read, since the traceback reflects all the calls within the `Model` method logic. For example:
```
from modelkit.core.model import Model
class CustomError(BaseException):
    pass
class ErrorModel(Model):
    def _predict(self, item):
        raise CustomError("something went wrong")
m = ErrorModel()
m.predict({})
```
Will raise a wall of errors:
```
---------------------------------------------------------------------------
CustomError                               Traceback (most recent call last)
<ipython-input-2-04a349b9b474> in <module>
     11 
     12 m = ErrorModel()
---> 13 m.predict({})

~/perso-workspace/modelkit/modelkit/core/model.py in predict(self, item, _force_compute, **kwargs)
    419     ) -> ReturnType:
    420         return next(
--> 421             self.predict_gen(iter((item,)), _force_compute=_force_compute, **kwargs)
    422         )
    423 

~/perso-workspace/modelkit/modelkit/core/model.py in predict_gen(self, items, batch_size, _callback, _force_compute, **kwargs)
    503         if cache_items:
    504             yield from self._predict_cache_items(
--> 505                 step, cache_items, _callback=_callback, **kwargs
    506             )
    507 

~/perso-workspace/modelkit/modelkit/core/model.py in _predict_cache_items(self, _step, cache_items, _callback, **kwargs)
    518             if res.missing
    519         ]
--> 520         predictions = iter(self._predict_batch(batch, **kwargs))
    521         for cache_item in cache_items:
    522             if cache_item.missing:

~/perso-workspace/modelkit/modelkit/core/model.py in _predict_batch(self, items, **kwargs)
    402 
    403     def _predict_batch(self, items: List[ItemType], **kwargs) -> List[ReturnType]:
--> 404         return [self._predict(p, **kwargs) for p in items]
    405 
    406     def __call__(

~/perso-workspace/modelkit/modelkit/core/model.py in <listcomp>(.0)
    402 
    403     def _predict_batch(self, items: List[ItemType], **kwargs) -> List[ReturnType]:
--> 404         return [self._predict(p, **kwargs) for p in items]
    405 
    406     def __call__(

<ipython-input-2-04a349b9b474> in _predict(self, item)
      8 class ErrorModel(Model):
      9     def _predict(self, item):
---> 10         raise CustomError("something went wrong")
     11 
     12 m = ErrorModel()

CustomError: something went wrong
```
In this PR, I catch all errors within the `predict` logic, and strip the traceback of any frame whose module is within modelkit. This gives the following result:
```
---------------------------------------------------------------------------
CustomError                               Traceback (most recent call last)
<ipython-input-1-0c897d332e88> in <module>
     19 
     20 m = ErrorModel()
---> 21 m.predict({})
~/perso-workspace/modelkit/modelkit/utils/traceback.py in wrapper(*args, **kwargs)
     29         except BaseException as exc:
     30             if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
---> 31                 raise strip_modelkit_traceback_frames(exc)
     32             raise exc
     33 
<ipython-input-1-0c897d332e88> in _predict(self, item)
     10 class ErrorModel(Model):
     11     def _predict(self, item):
---> 12         raise CustomError("something went wrong")
     13 
     14 
CustomError: something went wrong
```
Going from 7 frames to just 3. 

I am not sure I can get rid of the only remaining intermediate frame (raised in the decorator), but it seems good enough
