### PR TITLE
Add local asset discovery

### DIFF
--- a/modelkit/assets/manager.py
+++ b/modelkit/assets/manager.py
@@ -52,10 +52,17 @@ class AssetsManager:
             # no version is specified
             if not all_versions_list:
                 # and none exist
+                # in this case, the asset spec is likely a relative or absolute
+                # path to a file/directory
                 if os.path.exists(local_name):
+                    # if the asset spec resolves to WORKING_DIR/spec.name
                     return {"path": local_name}
                 elif os.path.exists(os.path.join(os.getcwd(), *spec.name.split("/"))):
+                    # if the assect spec resolves to cwd/spec.name
                     return {"path": os.path.join(os.getcwd(), *spec.name.split("/"))}
+                elif os.path.exists(spec.name):
+                    # if the asset spec is a valid absolute path
+                    return {"path": spec.name}
                 else:
                     raise errors.AssetDoesNotExistError(spec.name)
 

--- a/modelkit/assets/manager.py
+++ b/modelkit/assets/manager.py
@@ -54,6 +54,8 @@ class AssetsManager:
                 # and none exist
                 if os.path.exists(local_name):
                     return {"path": local_name}
+                elif os.path.exists(os.path.join(os.getcwd(), *spec.name.split("/"))):
+                    return {"path": os.path.join(os.getcwd(), *spec.name.split("/"))}
                 else:
                     raise errors.AssetDoesNotExistError(spec.name)
 

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -83,7 +83,7 @@ class AssetsManagerSettings(BaseSettings):
 
 VERSION_SPEC_RE = r"(?P<major_version>[0-9]+)(\.(?P<minor_version>[0-9]+))?"
 
-ASSET_NAME_RE = r"([A-Z]:/)?[a-zA-Z0-9]([a-zA-Z0-9\-\_\.\/]*[a-zA-Z0-9])?"
+ASSET_NAME_RE = r"(([A-Z]:/)|/)?[a-zA-Z0-9]([a-zA-Z0-9\-\_\.\/]*[a-zA-Z0-9])?"
 
 REMOTE_ASSET_RE = (
     f"^(?P<name>{ASSET_NAME_RE})"

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -83,7 +83,7 @@ class AssetsManagerSettings(BaseSettings):
 
 VERSION_SPEC_RE = r"(?P<major_version>[0-9]+)(\.(?P<minor_version>[0-9]+))?"
 
-ASSET_NAME_RE = r"[a-zA-Z0-9]([a-zA-Z0-9\-\_\.\/]*[a-zA-Z0-9])?"
+ASSET_NAME_RE = r"([A-Z]:/)?[a-zA-Z0-9]([a-zA-Z0-9\-\_\.\/]*[a-zA-Z0-9])?"
 
 REMOTE_ASSET_RE = (
     f"^(?P<name>{ASSET_NAME_RE})"

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -83,7 +83,7 @@ class AssetsManagerSettings(BaseSettings):
 
 VERSION_SPEC_RE = r"(?P<major_version>[0-9]+)(\.(?P<minor_version>[0-9]+))?"
 
-ASSET_NAME_RE = r"(([A-Z]:/)|/)?[a-zA-Z0-9]([a-zA-Z0-9\-\_\.\/]*[a-zA-Z0-9])?"
+ASSET_NAME_RE = r"(([A-Z]:\\)|/)?[a-zA-Z0-9]([a-zA-Z0-9\-\_\.\/\\]*[a-zA-Z0-9])?"
 
 REMOTE_ASSET_RE = (
     f"^(?P<name>{ASSET_NAME_RE})"

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -60,7 +60,9 @@ NAME_RE = r"[a-z0-9]([a-z0-9\-\_\.]*[a-z0-9])?"
 
 class AssetsManagerSettings(BaseSettings):
     remote_store: Optional[RemoteAssetsStoreSettings]
-    assets_dir: pydantic.DirectoryPath = pydantic.Field(..., env="WORKING_DIR")
+    assets_dir: pydantic.DirectoryPath = pydantic.Field(
+        default_factory=lambda: os.getcwd(), env="WORKING_DIR"
+    )
 
     @root_validator(pre=True)
     @classmethod

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -83,7 +83,7 @@ class AssetsManagerSettings(BaseSettings):
 
 VERSION_SPEC_RE = r"(?P<major_version>[0-9]+)(\.(?P<minor_version>[0-9]+))?"
 
-ASSET_NAME_RE = r"[a-z0-9]([a-z0-9\-\_\.\/]*[a-z0-9])?"
+ASSET_NAME_RE = r"[a-zA-Z0-9]([a-zA-Z0-9\-\_\.\/]*[a-zA-Z0-9])?"
 
 REMOTE_ASSET_RE = (
     f"^(?P<name>{ASSET_NAME_RE})"

--- a/tests/assets/test_asset_specification.py
+++ b/tests/assets/test_asset_specification.py
@@ -17,7 +17,7 @@ from modelkit.assets.settings import AssetSpec
         ("some_go/0d_name", True),
         ("SOME_GOOD_NAME_AS_WELL", True),
         ("50M3_G00D_N4ME_4S_W3LL", True),
-        ("C:/A/L0cAL/Windows/file.ext", True),
+        ("C:\\A\\L0cAL\\Windows\\file.ext", True),
     ],
 )
 def test_names(test, valid):
@@ -142,9 +142,9 @@ TEST_STRING_SPECS = [
     ),
     ("blabli/blebla[foo]", {"name": "blabli/blebla", "sub_part": "foo"}),
     (
-        "C:/A/L0cAL/Windows/file.ext",
+        "C:\A\L0cAL\Windows\\file.ext",
         {
-            "name": "C:/A/L0cAL/Windows/file.ext",
+            "name": "C:\A\L0cAL\Windows\\file.ext",
             "sub_part": None,
             "major_version": None,
             "minor_version": None,

--- a/tests/assets/test_asset_specification.py
+++ b/tests/assets/test_asset_specification.py
@@ -15,6 +15,8 @@ from modelkit.assets.settings import AssetSpec
         ("1", True),
         ("some_go0d_name", True),
         ("some_go/0d_name", True),
+        ("SOME_GOOD_NAME_AS_WELL", True),
+        ("50M3_G00D_N4ME_4S_W3LL", True),
     ],
 )
 def test_names(test, valid):
@@ -51,6 +53,7 @@ TEST_SPECS = [
     ),
     ({"name": "ontologies/skills.csv", "minor_version": "10"}, False),
     ({"name": "ontologies/skills.csv", "major_version": "10"}, True),
+    ({"name": "ontologies/SKILLS.csv", "major_version": "10"}, True),
     ({"name": "skills.csv", "not_a_field": "0.1", "file_path": "/ok/boomer"}, False),
 ]
 
@@ -67,6 +70,8 @@ def test_valid_spec(spec_dict, valid):
 TEST_STRING_SPECS = [
     ("blabli/blebla", {"name": "blabli/blebla"}),
     ("bl2_32_a.bli/bl3.debla", {"name": "bl2_32_a.bli/bl3.debla"}),
+    ("blabli/BLEBLA", {"name": "blabli/BLEBLA"}),
+    ("bl2_32_a.BLI/bl3.DEBLA", {"name": "bl2_32_a.BLI/bl3.DEBLA"}),
     (
         "blabli/blebla[/foo/bar]",
         {"name": "blabli/blebla", "sub_part": "/foo/bar"},
@@ -120,6 +125,16 @@ TEST_STRING_SPECS = [
         {
             "name": "blabli/blebla",
             "sub_part": "foo",
+            "major_version": 1,
+            "minor_version": 12,
+        },
+    ),
+    ("blabli/blebla[foo]", {"name": "blabli/blebla", "sub_part": "foo"}),
+    (
+        "blabli/BLEBLA:1.12[FOO]",
+        {
+            "name": "blabli/BLEBLA",
+            "sub_part": "FOO",
             "major_version": 1,
             "minor_version": 12,
         },

--- a/tests/assets/test_asset_specification.py
+++ b/tests/assets/test_asset_specification.py
@@ -150,6 +150,15 @@ TEST_STRING_SPECS = [
             "minor_version": None,
         },
     ),
+    (
+        "/modelkit/tmp-local-asset/1.0/subpart/README.md",
+        {
+            "name": "/modelkit/tmp-local-asset/1.0/subpart/README.md",
+            "sub_part": None,
+            "major_version": None,
+            "minor_version": None,
+        },
+    ),
 ]
 
 

--- a/tests/assets/test_asset_specification.py
+++ b/tests/assets/test_asset_specification.py
@@ -17,6 +17,7 @@ from modelkit.assets.settings import AssetSpec
         ("some_go/0d_name", True),
         ("SOME_GOOD_NAME_AS_WELL", True),
         ("50M3_G00D_N4ME_4S_W3LL", True),
+        ("C:/A/L0cAL/Windows/file.ext", True),
     ],
 )
 def test_names(test, valid):
@@ -140,6 +141,15 @@ TEST_STRING_SPECS = [
         },
     ),
     ("blabli/blebla[foo]", {"name": "blabli/blebla", "sub_part": "foo"}),
+    (
+        "C:/A/L0cAL/Windows/file.ext",
+        {
+            "name": "C:/A/L0cAL/Windows/file.ext",
+            "sub_part": None,
+            "major_version": None,
+            "minor_version": None,
+        },
+    ),
 ]
 
 

--- a/tests/assets/test_local_manager.py
+++ b/tests/assets/test_local_manager.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import pytest
 
@@ -17,6 +18,10 @@ def test_local_manager_no_versions(working_dir):
     manager = AssetsManager(assets_dir=working_dir)
     res = manager.fetch_asset("something/else/deep.txt", return_info=True)
     assert res["path"] == os.path.join(working_dir, "something", "else", "deep.txt")
+
+    manager = AssetsManager()
+    res = manager.fetch_asset("README.md", return_info=True)
+    assert res["path"] == os.path.join(os.getcwd(), "README.md")
 
     manager = AssetsManager(assets_dir=working_dir)
     res = manager.fetch_asset("something", return_info=True)
@@ -66,6 +71,22 @@ def test_local_manager_with_versions(working_dir):
     manager = AssetsManager(assets_dir=working_dir)
     res = manager.fetch_asset("something", return_info=True)
     assert res["path"] == os.path.join(working_dir, "something", "1.1")
+
+    try:
+        manager = AssetsManager()
+        local_dir = os.path.join("tmp-local-asset", "1.0", "subpart")
+        os.makedirs(local_dir)
+        shutil.copy("README.md", local_dir)
+
+        res = manager.fetch_asset(
+            "tmp-local-asset:1.0[subpart/README.md]", return_info=True
+        )
+        assert res["path"] == os.path.abspath(os.path.join(local_dir, "README.md"))
+
+        res = manager.fetch_asset("tmp-local-asset", return_info=True)
+        assert res["path"] == os.path.abspath(os.path.join(local_dir, ".."))
+    finally:
+        shutil.rmtree("tmp-local-asset")
 
 
 def test_local_manager_with_fetch(working_dir):

--- a/tests/assets/test_local_manager.py
+++ b/tests/assets/test_local_manager.py
@@ -85,6 +85,10 @@ def test_local_manager_with_versions(working_dir):
 
         res = manager.fetch_asset("tmp-local-asset", return_info=True)
         assert res["path"] == os.path.abspath(os.path.join(local_dir, ".."))
+
+        abs_path_to_readme = os.path.join(os.path.abspath(local_dir), "README.md")
+        res = manager.fetch_asset(abs_path_to_readme)
+        assert res["path"] == abs_path_to_readme
     finally:
         shutil.rmtree("tmp-local-asset")
 

--- a/tests/assets/test_settings.py
+++ b/tests/assets/test_settings.py
@@ -177,3 +177,9 @@ def test_assetsmanager_no_validation(monkeypatch, working_dir):
     monkeypatch.setenv("ENABLE_VALIDATION", "False")
     settings = LibrarySettings()
     assert not settings.enable_validation
+
+
+def test_assetsmanager_default():
+    settings = AssetsManagerSettings()
+    assert settings.assets_dir == Path(os.getcwd())
+    assert settings.remote_store is None


### PR DESCRIPTION
This PR aims at enabling simpler usages of modelkit and its assets management system:
- adding the current working dir as discoverable for AssetsManager
- allowing direct local files addressing in model CONFIGURATIONS

E.g.: the following becomes possible:
```json
    CONFIGURATIONS = {
        "your_model": {
            "asset": "vocabulary.txt"
        }
    }
```

Thanks @victorbenichoux for your explanations and review