### PR TITLE
library: add possibility to specify output type in .get

### DIFF
--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from structlog import get_logger
 
 from modelkit.core.library import LibrarySettings, ModelConfiguration, ModelLibrary
-from modelkit.core.model import Model
+from modelkit.core.model import BaseModel, Model
 
 logger = get_logger(__name__)
 
@@ -76,7 +76,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
         route_paths = route_paths or {}
         for model_name in self.svc.required_models:
-            m = self.svc.get(model_name)
+            m: BaseModel = self.svc.get(model_name)
             if not isinstance(m, Model):
                 continue
             path = route_paths.get(model_name, "/predict/" + model_name)

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -8,7 +8,7 @@ import copy
 import os
 import re
 from types import ModuleType
-from typing import Any, Dict, List, Mapping, Optional, Type, Union
+from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, Union, cast
 
 import humanize
 from pydantic import ValidationError
@@ -37,6 +37,9 @@ except ImportError:
 
 class ConfigurationNotFoundException(Exception):
     pass
+
+
+T = TypeVar("T", bound=Model)
 
 
 class ModelLibrary:
@@ -136,7 +139,7 @@ class ModelLibrary:
 
         return self._override_assets_manager
 
-    def get(self, name):
+    def get(self, name, model_type: Optional[Type[T]] = None) -> T:
         """
         Get a model by name
 
@@ -145,12 +148,12 @@ class ModelLibrary:
         """
         try:
             if not self._lazy_loading:
-                return self.models[name]
+                return cast(T, self.models[name])
             if name not in self.models:
                 self._load(name)
             if not self.models[name]._loaded:
                 self.models[name].load()
-            return self.models[name]
+            return cast(T, self.models[name])
         except KeyError:
             raise KeyError(
                 f"Model `{name}` not loaded."

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -147,15 +147,14 @@ class ModelLibrary:
         :return: required model
         """
         try:
-            if not self._lazy_loading:
-                m = self.models[name]
-                if model_type and not isinstance(m, model_type):
-                    raise ValueError(f"Model `{m}` is not an instance of {model_type}")
-                return cast(T, m)
-            if name not in self.models:
-                self._load(name)
-            if not self.models[name]._loaded:
-                self.models[name].load()
+            if self._lazy_loading:
+                # When in lazy mode ensure the model object and its dependencies
+                # are instantiated, this will download the asset
+                if name not in self.models:
+                    self._load(name)
+                # Ensure that it is loaded
+                if not self.models[name]._loaded:
+                    self.models[name].load()
             m = self.models[name]
             if model_type and not isinstance(m, model_type):
                 raise ValueError(f"Model `{m}` is not an instance of {model_type}")

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -151,7 +151,7 @@ class ModelLibrary:
                 m = self.models[name]
                 if model_type and not isinstance(m, model_type):
                     raise ValueError(f"Model `{m}` is not an instance of {model_type}")
-                return cast(T, self.models[name])
+                return cast(T, m)
             if name not in self.models:
                 self._load(name)
             if not self.models[name]._loaded:
@@ -159,7 +159,7 @@ class ModelLibrary:
             m = self.models[name]
             if model_type and not isinstance(m, model_type):
                 raise ValueError(f"Model `{m}` is not an instance of {model_type}")
-            return cast(T, self.models[name])
+            return cast(T, m)
         except KeyError:
             raise KeyError(
                 f"Model `{name}` not loaded."

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -148,11 +148,17 @@ class ModelLibrary:
         """
         try:
             if not self._lazy_loading:
+                m = self.models[name]
+                if model_type and not isinstance(m, model_type):
+                    raise ValueError(f"Model `{m}` is not an instance of {model_type}")
                 return cast(T, self.models[name])
             if name not in self.models:
                 self._load(name)
             if not self.models[name]._loaded:
                 self.models[name].load()
+            m = self.models[name]
+            if model_type and not isinstance(m, model_type):
+                raise ValueError(f"Model `{m}` is not an instance of {model_type}")
             return cast(T, self.models[name])
         except KeyError:
             raise KeyError(

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -20,6 +20,8 @@ TEST_CASES = [
     ("predict_pydantic_ok.py", False),
     ("predict_pydantic_bad.py", True),
     ("predict_list.py", False),
+    ("library_get_model_ko.py", True),
+    ("library_get_model_ok.py", False),
 ]
 
 

--- a/tests/testdata/typing/library_get_model_ko.py
+++ b/tests/testdata/typing/library_get_model_ko.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict
+
+from modelkit.core.library import ModelLibrary
+from modelkit.core.model import Model
+
+
+class SomeModelNoOtherFun(Model):
+    CONFIGURATIONS: Dict[str, Any] = {"something2": {}}
+
+
+lib = ModelLibrary(models=SomeModelNoOtherFun)
+
+m_get = lib.get("something2", model_type=SomeModelNoOtherFun)
+m_get.do_something_model_does_not()

--- a/tests/testdata/typing/library_get_model_ok.py
+++ b/tests/testdata/typing/library_get_model_ok.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict
+
+from modelkit.core.library import ModelLibrary
+from modelkit.core.model import Model
+
+
+class SomeModel(Model):
+    CONFIGURATIONS: Dict[str, Any] = {"something": {}}
+
+    def do_something_model_does_not(self):
+        return True
+
+
+lib = ModelLibrary(models=SomeModel)
+
+m2 = lib.get("something", model_type=SomeModel)
+m2.do_something_model_does_not()


### PR DESCRIPTION
`library.get` uses string keys to fetch models, which is slightly annoying since it means that Python does not know which type is returned. 
Here I suggest adding an optional keyword argument that specifies the output type of the `.get` function, such that `mypy` knows which type to expect.

