### PR TITLE
Fix walk non packages

### DIFF
--- a/tests/test_module_configure.py
+++ b/tests/test_module_configure.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+from modelkit.core.model_configuration import configure
+from tests import TEST_DIR
+
+
+def test_configure_package():
+    sys.path.append(os.path.join(TEST_DIR, "testdata"))
+    confs = configure(models="test_module")
+    assert len(confs) == 5
+
+
+def test_configure_module():
+    sys.path.append(os.path.join(TEST_DIR, "testdata"))
+    confs = configure(models="test_module.module_a")
+    assert len(confs) == 3


### PR DESCRIPTION
Configuring modules fails because they do not necessarily have a `__path__` attribute (while packages do).

For example, with
```
my_package
my_package/my_module.py
```
Trying to `configure(my_package.my_module)` fails

This PR fixes this.
@tgenin 