### PR TITLE
model.predict: allow None as batch size

### DIFF
--- a/modelkit/utils/traceback.py
+++ b/modelkit/utils/traceback.py
@@ -34,6 +34,7 @@ def strip_modelkit_traceback_frames(exc: BaseException):
 
 T = TypeVar("T", bound=Callable[..., Any])
 
+
 # Decorators to wrap prediction methods to simplify tracebacks
 def wrap_modelkit_exceptions(func: T) -> T:
     @functools.wraps(func)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -187,7 +187,7 @@ def test_modellibrary_required_models():
     assert m.__class__.__name__ == "SomeModel"
     assert m.model_settings == {}
     assert m.asset_path == ""
-    assert m.batch_size == 64
+    assert m.batch_size is None
 
 
 def test_modellibrary_no_models(monkeypatch):

--- a/tests/testdata/api/openapi.json
+++ b/tests/testdata/api/openapi.json
@@ -63,7 +63,7 @@
   "paths": {
     "/predict/batch/no_supported_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n└── batch size: 64                                                              \n```",
+        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n```",
         "operationId": "_endpoint_predict_batch_no_supported_model_post",
         "requestBody": {
           "content": {
@@ -105,7 +105,7 @@
     },
     "/predict/batch/some_complex_model": {
       "post": {
-        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n└── batch size: 64                                                              \n```",
+        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n```",
         "operationId": "_endpoint_predict_batch_some_complex_model_post",
         "requestBody": {
           "content": {
@@ -149,7 +149,7 @@
     },
     "/predict/batch/some_model": {
       "post": {
-        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n└── batch size: 64                                                              \n```",
+        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n```",
         "operationId": "_endpoint_predict_batch_some_model_post",
         "requestBody": {
           "content": {
@@ -191,7 +191,7 @@
     },
     "/predict/batch/unvalidated_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n└── batch size: 64                                                              \n```",
+        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n```",
         "operationId": "_endpoint_predict_batch_unvalidated_model_post",
         "requestBody": {
           "content": {
@@ -233,7 +233,7 @@
     },
     "/predict/no_supported_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n└── batch size: 64                                                              \n```",
+        "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n```",
         "operationId": "_endpoint_predict_no_supported_model_post",
         "requestBody": {
           "content": {
@@ -273,7 +273,7 @@
     },
     "/predict/some_complex_model": {
       "post": {
-        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n└── batch size: 64                                                              \n```",
+        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n```",
         "operationId": "_endpoint_predict_some_complex_model_post",
         "requestBody": {
           "content": {
@@ -313,7 +313,7 @@
     },
     "/predict/some_model": {
       "post": {
-        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n└── batch size: 64                                                              \n```",
+        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n```",
         "operationId": "_endpoint_predict_some_model_post",
         "requestBody": {
           "content": {
@@ -353,7 +353,7 @@
     },
     "/predict/unvalidated_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n└── batch size: 64                                                              \n```",
+        "description": "\n\n```                                                                                \n├── configuration: unvalidated_model                                            \n```",
         "operationId": "_endpoint_predict_unvalidated_model_post",
         "requestBody": {
           "content": {

--- a/tests/testdata/library_describe.txt
+++ b/tests/testdata/library_describe.txt
@@ -31,7 +31,6 @@ Models
 │   │                                                                           
 │   │           With **a lot** of documentation                                 
 │   ├── signature: ItemModel -> ItemModel                                       
-│   └── batch size: 64                                                          
 └── some_model_a : SomeSimpleValidatedModelA = SomeSimpleValidatedModelA        
     instance                                                                    
     ├── configuration: some_model_a                                             
@@ -39,4 +38,3 @@ Models
     │                                                                           
     │           that also has plenty more text                                  
     ├── signature: str -> str                                                   
-    └── batch size: 64                                                          


### PR DESCRIPTION
Currently the default batch size is 64, which is quite arbitrary.

Here I allow the batch size to be undefined, in which case it is either set for each model (via `model_settings`), or for each predict call, via `Model.predict_batch(..., batch_size=...)` or `Model.predict_gen(..., batch_size=...)`.

I had to think of good defaults:
- for `predict_batch` the batch size is the length of the items, such that all are computed at once
- for `predict_gen` the batch size is one, such that one item is consumed at every yield

I do this for both `Model` and `AsyncModel`. 

I also had to fix tests to expose the correct behavior: somehow the previous tests were completely useless (i.e. predict_gen was not evaluated at all, steps not reinitialized).