### PR TITLE
settings: bulk rename environment variables

### DIFF
--- a/docs/assets/environment.md
+++ b/docs/assets/environment.md
@@ -7,7 +7,7 @@ It is possible to set a default value of a package in which `ModelLibrary` will 
 | Environment variable | Default value | Notes |
 | --- | --- | --- |
 | `MODELKIT_DEFAULT_PACKAGE` | None | It has to be findable (on the `PYTHONPATH`) |
-| `WORKING_DIR` | None | Local directory to find assets, has to exist |
+| `MODELKIT_ASSETS_DIR` | None | Local directory to find assets, has to exist |
 
 ## AssetsManager settings
 
@@ -15,10 +15,10 @@ The parameters necessary to instantiate an `AssetsManager` can all be read from 
 
 | Environment variable | Default value | Parameter | Notes |
 | --- | --- | --- | --- |
-| `STORAGE_PROVIDER` | `gcs` | `storage_provider` | `gcs` (default), `s3` or `local` |
-| `ASSETS_BUCKET_NAME` | None | `bucket` | Bucket in which data is stored |
-| `STORAGE_PREFIX` | `modelkit-assets` | `storage_prefix` | Objects prefix |
-| `ASSETSMANAGER_TIMEOUT_S` | `300` | `timeout_s` | file lock timeout when downloading assets |
+| `MODELKIT_STORAGE_PROVIDER` | `gcs` | `storage_provider` | `gcs` (default), `s3` or `local` |
+| `MODELKIT_STORAGE_BUCKET` | None | `bucket` | Bucket in which data is stored |
+| `MODELKIT_STORAGE_PREFIX` | `modelkit-assets` | `storage_prefix` | Objects prefix |
+| `MODELKIT_STORAGE_TIMEOUT_S` | `300` | `timeout_s` | file lock timeout when downloading assets |
 
 More settings can be passed in order to configure the driver itself.
 
@@ -32,8 +32,8 @@ Then, configure the following variables:
 
 | Environment variable    | Value |
 | ----------------------- | ----- |
-| `STORAGE_PROVIDER`      | `s3`  |
-| `ASSETS_BUCKET_NAME`    |       |
+| `MODELKIT_STORAGE_PROVIDER`      | `s3`  |
+| `MODELKIT_STORAGE_BUCKET`    |       |
 | `AWS_ACCESS_KEY_ID`     |       |
 | `AWS_SECRET_ACCESS_KEY` |       |
 | `AWS_SESSION_TOKEN`     |       |
@@ -57,8 +57,8 @@ If `GOOGLE_APPLICATION_CREDENTIALS` is provided, it should point to a local JSON
 The local storage method is mostly used for development, and should not be useful to end users.
 It implements a `StorageDriver` from a local directory, that emulates other object providers.
 
-In this case `ASSETS_BUCKET_NAME` describes a local folder from which assets will be pulled.
+In this case `MODELKIT_STORAGE_BUCKET` describes a local folder from which assets will be pulled.
 
 ## Prediction Service
 
-`OVERRIDE_STORAGE_PREFIX` is used to set ModelLibrary `override_storage_prefix` setting
+`MODELKIT_STORAGE_PREFIX_OVERRIDE` is used to set ModelLibrary `override_storage_prefix` setting

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,8 +85,8 @@ To configure models from a package to be run in TF serving:
 modelkit tf-serving local-docker --models [PACKAGE]
 ```
 
-This will write a configuration file with relative paths to the model files. This is meant to be used by mounting the `WORKING_DIR` in the container under the path `/config`.
+This will write a configuration file with relative paths to the model files. This is meant to be used by mounting the `MODELKIT_ASSETS_DIR` in the container under the path `/config`.
 
 Other options include:
-- `local-process` To create a config file with absolute paths to the assets under `WORKING_DIR`
-- `remote` which will use whichever remote paths are found for the assets (i.e. as configured by the `STORAGE_PROVIDER`)
+- `local-process` To create a config file with absolute paths to the assets under `MODELKIT_ASSETS_DIR`
+- `remote` which will use whichever remote paths are found for the assets (i.e. as configured by the `MODELKIT_STORAGE_PROVIDER`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,31 +4,31 @@
 
 In order to run/deploy `modelkit` endpoints, you need to provide it with the necessary environment variables, most of them required by `modelkit.assets` to retrieve assets from the remote object store:
 
-- `ASSETS_BUCKET_NAME` (default: unset): override storage container
+- `MODELKIT_STORAGE_BUCKET` (default: unset): override storage container
   where assets are retrieved from.
-- `WORKING_DIR`: the local directory in which assets will be
+- `MODELKIT_ASSETS_DIR`: the local directory in which assets will be
   downloaded and cached. This needs to be a valid local directory.
-- `STORAGE_PROVIDER` (default: `gcs`) the storage provider (does not have to be set)
-    - for `STORAGE_PROVIDER=gcs`, the variable `GOOGLE_APPLICATION_CREDENTIALS` need to be
+- `MODELKIT_STORAGE_PROVIDER` (default: `gcs`) the storage provider (does not have to be set)
+    - for `MODELKIT_STORAGE_PROVIDER=gcs`, the variable `GOOGLE_APPLICATION_CREDENTIALS` need to be
       pointing to a service account credentials JSON file (this is not necessary on dev
       machines)
-    - for `STORAGE_PROVIDER=s3ssm`, you need to instantiate `AWS_PROFILE`
+    - for `MODELKIT_STORAGE_PROVIDER=s3ssm`, you need to instantiate `AWS_PROFILE`
 
 Refer to the [AssetsManager settings documentation](assets/environment.md) for more information.
 
-- `LAZY_LOADING` (defaults to `False`) toggles lazy loading mode for the `ModelLibrary`
-- `ENABLE_TF_SERVING` (default: `True`): Get tensorflow data from tensorflow server, instead of loading these data locally (if set to `False` you need to install tensorflow).
-    - `TF_SERVING_HOST` (default: `localhost`): IP address of tensorflow server
-    - `TF_SERVING_PORT` (default: `8501`): Port of tensorflow server
-    - `TF_SERVING_MODE` (default: `rest`): `rest` to use REST protocol of tensorflow server (port 8501), `grpc` to use GRPC protocol (port 8500)
+- `MODELKIT_LAZY_LOADING` (defaults to `False`) toggles lazy loading mode for the `ModelLibrary`
+- `MODELKIT_TF_SERVING_ENABLE` (default: `True`): Get tensorflow data from tensorflow server, instead of loading these data locally (if set to `False` you need to install tensorflow).
+    - `MODELKIT_TF_SERVING_HOST` (default: `localhost`): IP address of tensorflow server
+    - `MODELKIT_TF_SERVING_PORT` (default: `8501`): Port of tensorflow server
+    - `MODELKIT_TF_SERVING_MODE` (default: `rest`): `rest` to use REST protocol of tensorflow server (port 8501), `grpc` to use GRPC protocol (port 8500)
     - `TF_SERVING_TIMEOUT_S` (default: `60`): Timeout duration for tensorflow server calls
-- `CACHE_PROVIDER` (default: `None`) to use prediction caching
-  - if `CACHE_PROVIDER=redis`, use an external redis instance for caching:
-    - `CACHE_HOST` (default: `localhost`)
-    - `CACHE_PORT` (default: `6379`)
-  - if `CACHE_PROVIDER=native` use native caching (via [cachetools](https://cachetools.readthedocs.io/en/stable/)):
-    - `CACHE_IMPLEMENTATION` can be 
-    - `CACHE_MAX_SIZE` size of the cache
+- `MODELKIT_CACHE_PROVIDER` (default: `None`) to use prediction caching
+  - if `MODELKIT_CACHE_PROVIDER=redis`, use an external redis instance for caching:
+    - `MODELKIT_CACHE_HOST` (default: `localhost`)
+    - `MODELKIT_CACHE_PORT` (default: `6379`)
+  - if `MODELKIT_CACHE_PROVIDER=native` use native caching (via [cachetools](https://cachetools.readthedocs.io/en/stable/)):
+    - `MODELKIT_CACHE_IMPLEMENTATION` can be 
+    - `MODELKIT_CACHE_MAX_SIZE` size of the cache
 - `modelkit_ASYNC_MODE` (default to `None`) forces the `DistantHTTPModels` to use async mode.
 
 ## New Assets Testing Environment

--- a/docs/library/model_library.md
+++ b/docs/library/model_library.md
@@ -33,7 +33,7 @@ Sometimes this is not desirable, notably when using PySpark.
 
 Thus, when `lazy_loading=True` the `ModelLibrary` tries to delay the loading and
 deserialization of the assets as much as possible. You can also set this behavior by setting
-`LAZY_LOADING=True` in your environment.
+`MODELKIT_LAZY_LOADING=True` in your environment.
 
 Specifically:
 

--- a/docs/library/special/distant.md
+++ b/docs/library/special/distant.md
@@ -14,9 +14,9 @@ switch between them.
 
 In order to run a TF Serving docker locally, one first needs to download the models and write a configuration file.
 
-This can be achieved by `bin/tf_serving.py configure local-docker [SERVICE]`, which will write the configuration file under the local `WORKING_DIR`.
+This can be achieved by `bin/tf_serving.py configure local-docker [SERVICE]`, which will write the configuration file under the local `MODELKIT_ASSETS_DIR`.
 
-`SERVICE` refers to a key of the `modelkit.models.config.TF_SERVING_MODELS`, so essentially describes different subsets of the models that use TF serving. Possible keys are `modelkit` or `dataplayground`.
+`SERVICE` refers to a key of the `modelkit.models.config.MODELKIT_TF_SERVING_MODELS`, so essentially describes different subsets of the models that use TF serving. Possible keys are `modelkit` or `dataplayground`.
 
 The bash script `bin/run_tf_serving.sh` then runs the docker container exposing both the REST and gRPC endpoints.
 
@@ -24,7 +24,7 @@ Also see [the CLI documentation](../../cli.md).
 
 ## Details
 
-The CLI `bin/tf_serving.py configure local-docker` creates a configuration file for tensorflow serving, with the model locations refered to _relative to the container file system_. As a result, the TF serving container will expect that the `WORKING_DIR/modelkit-assets` is bound to the `/config` directory inside the container.
+The CLI `bin/tf_serving.py configure local-docker` creates a configuration file for tensorflow serving, with the model locations refered to _relative to the container file system_. As a result, the TF serving container will expect that the `MODELKIT_ASSETS_DIR/modelkit-assets` is bound to the `/config` directory inside the container.
 
 The container can then be started by pointing TF serving to the
 generated configuration file `--model_config_file=/config/modelkit.config`.

--- a/docs/library/special/tensorflow.md
+++ b/docs/library/special/tensorflow.md
@@ -88,13 +88,13 @@ This can be achieved by
 modelkit tf-serving local-docker --models [PACKAGE]
 ```
 
-The CLI creates a configuration file for tensorflow serving, with the model locations refered to _relative to the container file system_. As a result, the TF serving container will expect that the `WORKING_DIR` is bound to the `/config` directory inside the container.
+The CLI creates a configuration file for tensorflow serving, with the model locations refered to _relative to the container file system_. As a result, the TF serving container will expect that the `MODELKIT_ASSETS_DIR` is bound to the `/config` directory inside the container.
 
 Specifically, the CLI:
 
 - Instantiates a `ModelLibrary` with all configured models in `PACKAGE`
-- Downloads all necessary assets in the `WORKING_DIR`
-- writes a configuration file under the local `WORKING_DIR` with all TF models that are configured
+- Downloads all necessary assets in the `MODELKIT_ASSETS_DIR`
+- writes a configuration file under the local `MODELKIT_ASSETS_DIR` with all TF models that are configured
 
 The container can then be started by pointing TF serving to the generated configuration file `--model_config_file=/config/config.config`:
 
@@ -103,7 +103,7 @@ docker run \
         --name local-tf-serving \
         -d \
         -p 8500:8500 -p 8501:8501 \
-        -v ${WORKING_DIR}:/config \
+        -v ${MODELKIT_ASSETS_DIR}:/config \
         -t tensorflow/serving \
         --model_config_file=/config/config.config\
         --rest_api_port=8501\
@@ -120,10 +120,10 @@ See also:
 
 Several environment variables control how `modelkit` requests predictions from TF serving.
 
-- `ENABLE_TF_SERVING`: Controls whether to use TF serving or use TF locally as a lib
-- `TF_SERVING_HOST`: Host to connect to to request TF predictions
-- `TF_SERVING_PORT`: Port to connect to to request TF predictions
-- `TF_SERVING_MODE`: Can be `grpc` (with `grpc`) or `rest` (with `requests` for `TensorflowModel`, or with `aiohttp` for `AsyncTensorflowModel`)
+- `MODELKIT_TF_SERVING_ENABLE`: Controls whether to use TF serving or use TF locally as a lib
+- `MODELKIT_TF_SERVING_HOST`: Host to connect to to request TF predictions
+- `MODELKIT_TF_SERVING_PORT`: Port to connect to to request TF predictions
+- `MODELKIT_TF_SERVING_MODE`: Can be `grpc` (with `grpc`) or `rest` (with `requests` for `TensorflowModel`, or with `aiohttp` for `AsyncTensorflowModel`)
 - `TF_SERVING_TIMEOUT_S`: timeout to wait for the first TF serving response
 
 All of these parameters can be set programmatically (and passed to the `ModelLibrary`'s settings):

--- a/modelkit/assets/cli.py
+++ b/modelkit/assets/cli.py
@@ -88,8 +88,8 @@ def _check_asset_file_number(asset_path):
 @assets_cli.command("new")
 @click.argument("asset_path")
 @click.argument("asset_spec")
-@click.option("--bucket", envvar="ASSETS_BUCKET_NAME")
-@click.option("--storage-prefix", envvar="STORAGE_PREFIX")
+@click.option("--bucket", envvar="MODELKIT_STORAGE_BUCKET")
+@click.option("--storage-prefix", envvar="MODELKIT_STORAGE_PREFIX")
 @click.option("--dry-run", is_flag=True)
 def new(asset_path, asset_spec, bucket, storage_prefix, dry_run):
     """
@@ -141,8 +141,8 @@ def new(asset_path, asset_spec, bucket, storage_prefix, dry_run):
 @click.option(
     "--bump-major", is_flag=True, help="Push a new major version (1.0, 2.0, etc.)"
 )
-@click.option("--bucket", envvar="ASSETS_BUCKET_NAME")
-@click.option("--storage-prefix", envvar="STORAGE_PREFIX")
+@click.option("--bucket", envvar="MODELKIT_STORAGE_BUCKET")
+@click.option("--storage-prefix", envvar="MODELKIT_STORAGE_PREFIX")
 @click.option("--dry-run", is_flag=True)
 def update(asset_path, asset_spec, bucket, storage_prefix, bump_major, dry_run):
     """
@@ -242,8 +242,8 @@ def update(asset_path, asset_spec, bucket, storage_prefix, bump_major, dry_run):
 
 
 @assets_cli.command("list")
-@click.option("--bucket", envvar="ASSETS_BUCKET_NAME")
-@click.option("--storage-prefix", envvar="STORAGE_PREFIX")
+@click.option("--bucket", envvar="MODELKIT_STORAGE_BUCKET")
+@click.option("--storage-prefix", envvar="MODELKIT_STORAGE_PREFIX")
 def list(bucket, storage_prefix):
     """lists all available assets and their versions."""
     manager = RemoteAssetsStore(

--- a/modelkit/assets/drivers/gcs.py
+++ b/modelkit/assets/drivers/gcs.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 class GCSDriverSettings(pydantic.BaseSettings):
-    bucket: str = pydantic.Field(..., env="ASSETS_BUCKET_NAME")
+    bucket: str = pydantic.Field(..., env="MODELKIT_STORAGE_BUCKET")
     service_account_path: Optional[str] = None
     client: Optional[storage.Client]
 

--- a/modelkit/assets/drivers/local.py
+++ b/modelkit/assets/drivers/local.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 
 
 class LocalDriverSettings(BaseSettings):
-    bucket: pydantic.DirectoryPath = pydantic.Field(..., env="ASSETS_BUCKET_NAME")
+    bucket: pydantic.DirectoryPath = pydantic.Field(..., env="MODELKIT_STORAGE_BUCKET")
 
     class Config:
         extra = "forbid"

--- a/modelkit/assets/drivers/s3.py
+++ b/modelkit/assets/drivers/s3.py
@@ -17,7 +17,7 @@ except ImportError:
 
 
 class S3DriverSettings(BaseSettings):
-    bucket: str = pydantic.Field(..., env="ASSETS_BUCKET_NAME")
+    bucket: str = pydantic.Field(..., env="MODELKIT_STORAGE_BUCKET")
     aws_access_key_id: str = pydantic.Field(None, env="AWS_ACCESS_KEY_ID")
     aws_secret_access_key: str = pydantic.Field(None, env="AWS_SECRET_ACCESS_KEY")
     aws_default_region: str = pydantic.Field(None, env="AWS_DEFAULT_REGION")

--- a/modelkit/assets/manager.py
+++ b/modelkit/assets/manager.py
@@ -55,7 +55,7 @@ class AssetsManager:
                 # in this case, the asset spec is likely a relative or absolute
                 # path to a file/directory
                 if os.path.exists(local_name):
-                    # if the asset spec resolves to WORKING_DIR/spec.name
+                    # if the asset spec resolves to MODELKIT_ASSETS_DIR/spec.name
                     return {"path": local_name}
                 elif os.path.exists(os.path.join(os.getcwd(), *spec.name.split("/"))):
                     # if the assect spec resolves to cwd/spec.name

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -10,7 +10,7 @@ from modelkit.assets.drivers.local import LocalDriverSettings
 from modelkit.assets.drivers.s3 import S3DriverSettings
 from modelkit.assets.errors import InvalidAssetSpecError
 
-SUPPORTED_STORAGE_PROVIDERS = {"s3", "gcs", "local"}
+SUPPORTED_MODELKIT_STORAGE_PROVIDERS = {"s3", "gcs", "local"}
 
 
 class DriverSettings(BaseSettings):
@@ -23,11 +23,11 @@ class DriverSettings(BaseSettings):
         if "settings" in fields:
             return fields
         storage_provider = fields.pop("storage_provider", None) or os.getenv(
-            "STORAGE_PROVIDER", None
+            "MODELKIT_STORAGE_PROVIDER", None
         )
         if not storage_provider:
             return {"storage_provider": None, "settings": None}
-        if storage_provider not in SUPPORTED_STORAGE_PROVIDERS:
+        if storage_provider not in SUPPORTED_MODELKIT_STORAGE_PROVIDERS:
             raise ValueError(f"Unkown storage provider `{storage_provider}`.")
         if storage_provider == "gcs":
             settings = GCSDriverSettings(**fields)
@@ -40,8 +40,10 @@ class DriverSettings(BaseSettings):
 
 class RemoteAssetsStoreSettings(BaseSettings):
     driver: DriverSettings
-    timeout_s: float = pydantic.Field(5 * 60, env="ASSETSMANAGER_TIMEOUT_S")
-    storage_prefix: str = pydantic.Field("modelkit-assets", env="STORAGE_PREFIX")
+    timeout_s: float = pydantic.Field(5 * 60, env="MODELKIT_STORAGE_TIMEOUT_S")
+    storage_prefix: str = pydantic.Field(
+        "modelkit-assets", env="MODELKIT_STORAGE_PREFIX"
+    )
 
     @root_validator(pre=True)
     @classmethod
@@ -61,7 +63,7 @@ NAME_RE = r"[a-z0-9]([a-z0-9\-\_\.]*[a-z0-9])?"
 class AssetsManagerSettings(BaseSettings):
     remote_store: Optional[RemoteAssetsStoreSettings]
     assets_dir: pydantic.DirectoryPath = pydantic.Field(
-        default_factory=lambda: os.getcwd(), env="WORKING_DIR"
+        default_factory=lambda: os.getcwd(), env="MODELKIT_ASSETS_DIR"
     )
 
     @root_validator(pre=True)

--- a/modelkit/core/settings.py
+++ b/modelkit/core/settings.py
@@ -4,10 +4,10 @@ import pydantic
 
 
 class TFServingSettings(pydantic.BaseSettings):
-    enable: bool = pydantic.Field(False, env="ENABLE_TF_SERVING")
-    mode: str = pydantic.Field("rest", env="TF_SERVING_MODE")
-    host: str = pydantic.Field("localhost", env="TF_SERVING_HOST")
-    port: int = pydantic.Field(None, env="TF_SERVING_PORT")
+    enable: bool = pydantic.Field(False, env="MODELKIT_TF_SERVING_ENABLE")
+    mode: str = pydantic.Field("rest", env="MODELKIT_TF_SERVING_MODE")
+    host: str = pydantic.Field("localhost", env="MODELKIT_TF_SERVING_HOST")
+    port: int = pydantic.Field(None, env="MODELKIT_TF_SERVING_PORT")
 
     @pydantic.validator("port")
     @classmethod
@@ -18,12 +18,12 @@ class TFServingSettings(pydantic.BaseSettings):
 
 
 class CacheSettings(pydantic.BaseSettings):
-    cache_provider: Optional[str] = pydantic.Field(None, env="CACHE_PROVIDER")
+    cache_provider: Optional[str] = pydantic.Field(None, env="MODELKIT_CACHE_PROVIDER")
 
 
 class RedisSettings(CacheSettings):
-    host: str = pydantic.Field("localhost", env="CACHE_HOST")
-    port: int = pydantic.Field(6379, env="CACHE_PORT")
+    host: str = pydantic.Field("localhost", env="MODELKIT_CACHE_HOST")
+    port: int = pydantic.Field(6379, env="MODELKIT_CACHE_PORT")
 
     @pydantic.validator("cache_provider")
     def _validate_type(cls, v):
@@ -33,8 +33,8 @@ class RedisSettings(CacheSettings):
 
 
 class NativeCacheSettings(CacheSettings):
-    implementation: str = pydantic.Field("LRU", env="CACHE_IMPLEMENTATION")
-    maxsize: int = pydantic.Field(128, env="CACHE_MAX_SIZE")
+    implementation: str = pydantic.Field("LRU", env="MODELKIT_CACHE_IMPLEMENTATION")
+    maxsize: int = pydantic.Field(128, env="MODELKIT_CACHE_MAX_SIZE")
 
     @pydantic.validator("cache_provider")
     def _validate_type(cls, v):
@@ -58,12 +58,11 @@ def cache_settings():
 
 
 class LibrarySettings(pydantic.BaseSettings):
-    lazy_loading: bool = pydantic.Field(False, env="LAZY_LOADING")
-    async_mode: bool = pydantic.Field(None, env="MODELKIT_ASYNC_MODE")
+    lazy_loading: bool = pydantic.Field(False, env="MODELKIT_LAZY_LOADING")
     override_storage_prefix: Optional[str] = pydantic.Field(
-        None, env="OVERRIDE_STORAGE_PREFIX"
+        None, env="MODELKIT_STORAGE_PREFIX_OVERRIDE"
     )
-    enable_validation: bool = pydantic.Field(True, env="ENABLE_VALIDATION")
+    enable_validation: bool = pydantic.Field(True, env="MODELKIT_ENABLE_VALIDATION")
     tf_serving: TFServingSettings = pydantic.Field(
         default_factory=lambda: TFServingSettings()
     )

--- a/modelkit/testing/fixtures.py
+++ b/modelkit/testing/fixtures.py
@@ -115,7 +115,8 @@ def tf_serving_fixture(request, svc, deployment="docker"):
         proc = subprocess.Popen(
             [
                 "tensorflow_model_server",
-                "--model_config_file=" f"{os.environ['WORKING_DIR']}/testing.config",
+                "--model_config_file="
+                f"{os.environ['MODELKIT_ASSETS_DIR']}/testing.config",
             ]
             + cmd
         )
@@ -138,7 +139,7 @@ def tf_serving_fixture(request, svc, deployment="docker"):
                 "--name",
                 "modelkit-tfserving-tests",
                 "--volume",
-                f"{os.environ['WORKING_DIR']}:/config",
+                f"{os.environ['MODELKIT_ASSETS_DIR']}:/config",
                 "-p",
                 "8500:8500",
                 "-p",

--- a/modelkit/utils/traceback.py
+++ b/modelkit/utils/traceback.py
@@ -34,6 +34,7 @@ def strip_modelkit_traceback_frames(exc: BaseException):
 
 T = TypeVar("T", bound=Callable[..., Any])
 
+
 # Decorators to wrap prediction methods to simplify tracebacks
 def wrap_modelkit_exceptions(func: T) -> T:
     @functools.wraps(func)

--- a/tests/assets/test_settings.py
+++ b/tests/assets/test_settings.py
@@ -130,9 +130,9 @@ def test_remote_assets_store_settings(monkeypatch, settings_dict, valid):
 
 
 def test_assetsmanager_minimal(monkeypatch, working_dir):
-    monkeypatch.setenv("WORKING_DIR", working_dir)
-    monkeypatch.setenv("ASSETS_BUCKET_NAME", "some-bucket")
-    monkeypatch.setenv("STORAGE_PROVIDER", "gcs")
+    monkeypatch.setenv("MODELKIT_ASSETS_DIR", working_dir)
+    monkeypatch.setenv("MODELKIT_STORAGE_BUCKET", "some-bucket")
+    monkeypatch.setenv("MODELKIT_STORAGE_PROVIDER", "gcs")
     settings = AssetsManagerSettings()
     assert settings.remote_store.driver.storage_provider == "gcs"
     assert settings.remote_store.driver.settings == GCSDriverSettings()
@@ -142,13 +142,13 @@ def test_assetsmanager_minimal(monkeypatch, working_dir):
 
 
 def test_assetsmanager_minimal_provider(monkeypatch, working_dir):
-    monkeypatch.setenv("WORKING_DIR", working_dir)
-    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("MODELKIT_ASSETS_DIR", working_dir)
+    monkeypatch.setenv("MODELKIT_STORAGE_PROVIDER", "local")
 
     settings = AssetsManagerSettings()
     assert not settings.remote_store
 
-    monkeypatch.setenv("ASSETS_BUCKET_NAME", working_dir)
+    monkeypatch.setenv("MODELKIT_STORAGE_BUCKET", working_dir)
     settings = AssetsManagerSettings()
     assert settings.remote_store.driver.storage_provider == "local"
     assert settings.remote_store.driver.settings == LocalDriverSettings()
@@ -157,10 +157,10 @@ def test_assetsmanager_minimal_provider(monkeypatch, working_dir):
 
 
 def test_assetsmanager_minimal_prefix(monkeypatch, working_dir):
-    monkeypatch.setenv("WORKING_DIR", working_dir)
-    monkeypatch.setenv("ASSETS_BUCKET_NAME", "some-bucket")
-    monkeypatch.setenv("STORAGE_PREFIX", "a-prefix")
-    monkeypatch.setenv("STORAGE_PROVIDER", "gcs")
+    monkeypatch.setenv("MODELKIT_ASSETS_DIR", working_dir)
+    monkeypatch.setenv("MODELKIT_STORAGE_BUCKET", "some-bucket")
+    monkeypatch.setenv("MODELKIT_STORAGE_PREFIX", "a-prefix")
+    monkeypatch.setenv("MODELKIT_STORAGE_PROVIDER", "gcs")
 
     settings = AssetsManagerSettings()
     assert settings.remote_store.driver.storage_provider == "gcs"
@@ -171,10 +171,10 @@ def test_assetsmanager_minimal_prefix(monkeypatch, working_dir):
 
 
 def test_assetsmanager_no_validation(monkeypatch, working_dir):
-    monkeypatch.setenv("WORKING_DIR", working_dir)
+    monkeypatch.setenv("MODELKIT_ASSETS_DIR", working_dir)
     settings = LibrarySettings()
     assert settings.enable_validation
-    monkeypatch.setenv("ENABLE_VALIDATION", "False")
+    monkeypatch.setenv("MODELKIT_ENABLE_VALIDATION", "False")
     settings = LibrarySettings()
     assert not settings.enable_validation
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,15 +21,23 @@ def working_dir(base_dir):
 
 def clean_env():
     for env_var in [
-        "ASSETS_DIR",
-        "WORKING_DIR",
-        "ASSETS_BUCKET_NAME",
-        "STORAGE_PREFIX",
-        "STORAGE_PROVIDER",
-        "LAZY_LOADING",
-        "ASSETSMANAGER_PREFIX",
-        "ASSETSMANAGER_TIMEOUT_S",
-        "ENABLE_VALIDATION",
+        "MODELKIT_ASSETS_DIR",
+        "MODELKIT_CACHE_HOST",
+        "MODELKIT_CACHE_IMPLEMENTATION",
+        "MODELKIT_CACHE_MAX_SIZE",
+        "MODELKIT_CACHE_PORT",
+        "MODELKIT_CACHE_PROVIDER",
+        "MODELKIT_DEFAULT_PACKAGE",
+        "MODELKIT_ENABLE_VALIDATION",
+        "MODELKIT_LAZY_LOADING",
+        "MODELKIT_STORAGE_BUCKET",
+        "MODELKIT_STORAGE_PREFIX_OVERRIDE",
+        "MODELKIT_STORAGE_PREFIX",
+        "MODELKIT_STORAGE_PROVIDER",
+        "MODELKIT_STORAGE_TIMEOUT_S",
+        "MODELKIT_TF_SERVING_ENABLE",
+        "MODELKIT_TF_SERVING_MODE",
+        "MODELKIT_TF_SERVING_PORT",
     ]:
         os.environ.pop(env_var, None)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -369,10 +369,10 @@ def test_required_models():
 
 
 def test_lazy_loading_setting(monkeypatch):
-    monkeypatch.delenv("LAZY_LOADING", raising=False)
+    monkeypatch.delenv("MODELKIT_LAZY_LOADING", raising=False)
     settings = LibrarySettings()
     assert not settings.lazy_loading
-    monkeypatch.setenv("LAZY_LOADING", "True")
+    monkeypatch.setenv("MODELKIT_LAZY_LOADING", "True")
     settings = LibrarySettings()
     assert settings.lazy_loading
 

--- a/tests/test_tf_model.py
+++ b/tests/test_tf_model.py
@@ -58,10 +58,10 @@ def test_tf_model_local_path():
 
 
 def test_tf_model(monkeypatch, working_dir):
-    monkeypatch.setenv("ASSETS_BUCKET_NAME", TEST_DIR)
-    monkeypatch.setenv("STORAGE_PREFIX", "testdata")
-    monkeypatch.setenv("STORAGE_PROVIDER", "local")
-    monkeypatch.setenv("WORKING_DIR", working_dir)
+    monkeypatch.setenv("MODELKIT_STORAGE_BUCKET", TEST_DIR)
+    monkeypatch.setenv("MODELKIT_STORAGE_PREFIX", "testdata")
+    monkeypatch.setenv("MODELKIT_STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("MODELKIT_ASSETS_DIR", working_dir)
 
     lib = ModelLibrary(models=DummyTFModel)
     assert not lib.settings.tf_serving.enable
@@ -72,10 +72,10 @@ def test_tf_model(monkeypatch, working_dir):
 
 @pytest.fixture(scope="function")
 def tf_serving(request, monkeypatch, working_dir):
-    monkeypatch.setenv("WORKING_DIR", working_dir)
-    monkeypatch.setenv("ASSETS_BUCKET_NAME", TEST_DIR)
-    monkeypatch.setenv("STORAGE_PREFIX", "testdata")
-    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("MODELKIT_ASSETS_DIR", working_dir)
+    monkeypatch.setenv("MODELKIT_STORAGE_BUCKET", TEST_DIR)
+    monkeypatch.setenv("MODELKIT_STORAGE_PREFIX", "testdata")
+    monkeypatch.setenv("MODELKIT_STORAGE_PROVIDER", "local")
 
     lib = ModelLibrary(models=DummyTFModel, settings={"lazy_loading": True})
     yield tf_serving_fixture(request, lib)

--- a/tests/testdata/library_describe.txt
+++ b/tests/testdata/library_describe.txt
@@ -1,6 +1,5 @@
 Settings                                                                        
 ├── lazy_loading : bool = False                                                 
-├── async_mode : bool = None                                                    
 ├── override_storage_prefix : str = None                                        
 ├── enable_validation : bool = True                                             
 ├── tf_serving : TFServingSettings                                              


### PR DESCRIPTION
We now have all variables renamed with a `MODELKIT_` prefix.

Here is a list of the non trivial changes:
```
WORKING_DIR -> MODELKIT_ASSETS_DIR 
ENABLE_TF_SERVING -> MODELKIT_TF_SERVING_ENABLE 
ASSETS_BUCKET_NAME -> MODELKIT_STORAGE_BUCKET 
OVERRIDE_STORAGE_PREFIX -> MODELKIT_STORAGE_PREFIX_OVERRIDE 
ASSETSMANAGER_TIMEOUT_S -> MODELKIT_STORAGE_TIMEOUT_S 
```

All of these only had `MODELKIT_` prepended:
```
MODELKIT_CACHE_HOST 
MODELKIT_CACHE_IMPLEMENTATION 
MODELKIT_CACHE_MAX_SIZE 
MODELKIT_CACHE_PORT 
MODELKIT_CACHE_PROVIDER 
MODELKIT_DEFAULT_PACKAGE 
MODELKIT_ENABLE_VALIDATION 
MODELKIT_LAZY_LOADING 
MODELKIT_STORAGE_BUCKET 
MODELKIT_STORAGE_PREFIX 
MODELKIT_STORAGE_PROVIDER 
MODELKIT_STORAGE_TIMEOUT_S 
MODELKIT_TF_SERVING_MODE 
MODELKIT_TF_SERVING_PORT 
```