### PR TITLE
library/models: rework connection logic

### DIFF
--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -46,7 +46,7 @@ class ModelkitAPIRouter(fastapi.APIRouter):
         )
 
     async def _on_shutdown(self):
-        await self.svc.close_connections()
+        await self.svc.aclose()
 
 
 class ModelkitAutoAPIRouter(ModelkitAPIRouter):

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -531,6 +531,9 @@ class Model(BaseModel[ItemType, ReturnType]):
         if _callback:
             _callback(_step, batch, predictions)
 
+    def close(self):
+        pass
+
 
 class AsyncModel(BaseModel[ItemType, ReturnType]):
     async def _predict(self, item: ItemType, **kwargs) -> ReturnType:
@@ -671,6 +674,9 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
                 )
         if _callback:
             _callback(_step, batch, predictions)
+
+    async def close(self):
+        pass
 
 
 class WrappedAsyncModel:

--- a/modelkit/core/models/distant_model.py
+++ b/modelkit/core/models/distant_model.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 import aiohttp
 import requests
@@ -49,7 +50,7 @@ class AsyncDistantHTTPModel(AsyncModel[ItemType, ReturnType]):
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
         self.endpoint = self.model_settings["endpoint"]
-        self.aiohttp_session = None
+        self.aiohttp_session: Optional[aiohttp.ClientSession] = None
 
     def _load(self):
         pass
@@ -68,12 +69,16 @@ class AsyncDistantHTTPModel(AsyncModel[ItemType, ReturnType]):
                 )
             return await response.json()
 
+    async def close(self):
+        if self.aiohttp_session:
+            return self.aiohttp_session.close()
+
 
 class DistantHTTPModel(Model[ItemType, ReturnType]):
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
         self.endpoint = self.model_settings["endpoint"]
-        self.requests_session = None
+        self.requests_session: Optional[requests.Session] = None
 
     def _load(self):
         pass
@@ -91,3 +96,7 @@ class DistantHTTPModel(Model[ItemType, ReturnType]):
                 response.status_code, response.reason, response.text
             )
         return response.json()
+
+    def close(self):
+        if self.requests_session:
+            return self.requests_session.close()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -37,6 +37,9 @@ def test_compose_sync_async_generator_fail():
             await asyncio.sleep(0)
             return item
 
+        async def close(self):
+            await asyncio.sleep(0)
+
     class ComposedModel(Model):
         CONFIGURATIONS = {"composed_model": {"model_dependencies": {"async_model"}}}
 
@@ -56,6 +59,8 @@ def test_compose_sync_async_generator_fail():
         # raises
         # TypeError: object async_generator can't be used in 'await' expression
         assert m.predict({"hello": "world"}) == {"hello": "world"}
+
+    library.close()
 
 
 @pytest.mark.asyncio
@@ -92,6 +97,7 @@ async def test_compose_async_sync_async(event_loop):
         assert res == {"hello": "world"}
     res = await m.predict_batch([{"hello": "world"}])
     assert res == [{"hello": "world"}]
+    await library.aclose()
 
 
 async def _do_async(model, item, expected=None):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -218,7 +218,7 @@ async def test_redis_cache_async(redis_service, event_loop):
 
     await _do_model_test_async(m, ITEMS)
     await _do_model_test_async(m_multi, ITEMS)
-    await svc.close_connections()
+    await svc.aclose()
 
     m_validated = svc.get("model_validated")
     await _do_model_test_async(m_validated, ITEMS)

--- a/tests/test_distant_http_model.py
+++ b/tests/test_distant_http_model.py
@@ -69,7 +69,7 @@ async def test_distant_http_model(run_mocked_service, event_loop):
     with pytest.raises(AssertionError):
         assert ITEM == m(ITEM)
     await _check_service_async(m, ITEM)
-    await svc.close_connections()
+    await svc.aclose()
 
     # Test with synchronous mode
     m = svc.get("some_model_sync")

--- a/tests/test_tf_model.py
+++ b/tests/test_tf_model.py
@@ -126,9 +126,8 @@ async def test_iso_serving_mode(tf_serving, event_loop):
 
     _compare_models(model_rest, model_grpc, TEST_ITEMS)
 
-    await svc_serving_rest.close_connections()
-    await svc_serving_grpc.close_connections()
-    assert model_rest.aiohttp_session is None
+    await svc_serving_rest.aclose()
+    await svc_serving_grpc.aclose()
 
 
 def compare_result(x, y, tolerance):
@@ -228,8 +227,8 @@ async def test_iso_async(tf_serving, event_loop):
     async_m_jt2s = svc.get("dummy_tf_model_async")
 
     await _compare_models_async(m_jt2s, async_m_jt2s, TEST_ITEMS)
-    await svc.close_connections()
-    assert async_m_jt2s.aiohttp_session is None
+    await svc.aclose()
+    assert async_m_jt2s.aiohttp_session.closed
 
 
 async def _compare_models_async(model, model_async, items, tolerance=1e-2):


### PR DESCRIPTION
In this PR I rework the connection closing logic.

Each of `Model` and `AsyncModel` expose a `close` method, and the library exposes both a sync and an async version of `close` (resp. `aclose`) for the library. 

