### PR TITLE
api: use async endpoint for async models

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import platform
 
@@ -9,7 +10,7 @@ from starlette.testclient import TestClient
 
 from modelkit import testing
 from modelkit.api import ModelkitAutoAPIRouter
-from modelkit.core.model import Asset, Model
+from modelkit.core.model import Asset, AsyncModel, Model
 from tests import TEST_DIR
 
 
@@ -51,6 +52,13 @@ def api_no_type(event_loop):
         def _predict(self, item):
             return item
 
+    class SomeAsyncModel(AsyncModel):
+        CONFIGURATIONS = {"async_model": {}}
+
+        async def _predict(self, item):
+            await asyncio.sleep(0)
+            return item
+
     class ValidationNotSupported(Model[np.ndarray, np.ndarray]):
         CONFIGURATIONS = {"no_supported_model": {}}
 
@@ -74,6 +82,7 @@ def api_no_type(event_loop):
             "some_model",
             "some_complex_model",
             "some_asset",
+            "async_model",
         ],
         models=[
             ValidationNotSupported,
@@ -81,6 +90,7 @@ def api_no_type(event_loop):
             SomeSimpleValidatedModel,
             SomeComplexValidatedModel,
             SomeAsset,
+            SomeAsyncModel,
         ],
     )
 

--- a/tests/testdata/api/openapi.json
+++ b/tests/testdata/api/openapi.json
@@ -61,6 +61,88 @@
   },
   "openapi": "3.0.2",
   "paths": {
+    "/predict/async_model": {
+      "post": {
+        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n```",
+        "operationId": "_endpoint_predict_async_model_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "Item"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": " Endpoint",
+        "tags": [
+          "tests.test_api"
+        ]
+      }
+    },
+    "/predict/batch/async_model": {
+      "post": {
+        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n```",
+        "operationId": "_endpoint_predict_batch_async_model_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {},
+                "title": "Item",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": " Endpoint",
+        "tags": [
+          "tests.test_api"
+        ]
+      }
+    },
     "/predict/batch/no_supported_model": {
       "post": {
         "description": "\n\n```                                                                                \n├── configuration: no_supported_model                                           \n├── signature: ndarray -> ndarray                                               \n```",


### PR DESCRIPTION
For now, the async models were not exposed through `modelkit.api`, even it is entirely possible. 