### PR TITLE
batching: pass batch_size to _predict_* methods

### DIFF
--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -487,7 +487,11 @@ class Model(BaseModel[ItemType, ReturnType]):
                 n_items_to_compute == batch_size or n_items_from_cache == 2 * batch_size
             ):
                 yield from self._predict_cache_items(
-                    step, cache_items, _callback=_callback, **kwargs
+                    step,
+                    cache_items,
+                    _callback=_callback,
+                    batch_size=batch_size,
+                    **kwargs,
                 )
                 cache_items = []
                 n_items_to_compute = 0
@@ -496,7 +500,7 @@ class Model(BaseModel[ItemType, ReturnType]):
 
         if cache_items:
             yield from self._predict_cache_items(
-                step, cache_items, _callback=_callback, **kwargs
+                step, cache_items, _callback=_callback, batch_size=batch_size, **kwargs
             )
 
     def _predict_cache_items(
@@ -626,7 +630,11 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
                 n_items_to_compute == batch_size or n_items_from_cache == 2 * batch_size
             ):
                 async for r in self._predict_cache_items(
-                    step, cache_items, _callback=_callback, **kwargs
+                    step,
+                    cache_items,
+                    batch_size=batch_size,
+                    _callback=_callback,
+                    **kwargs,
                 ):
                     yield r
                 cache_items = []
@@ -636,7 +644,7 @@ class AsyncModel(BaseModel[ItemType, ReturnType]):
 
         if cache_items:
             async for r in self._predict_cache_items(
-                step, cache_items, _callback=_callback, **kwargs
+                step, cache_items, batch_size=batch_size, _callback=_callback, **kwargs
             ):
                 yield r
 

--- a/modelkit/core/models/distant_model.py
+++ b/modelkit/core/models/distant_model.py
@@ -55,7 +55,7 @@ class AsyncDistantHTTPModel(AsyncModel[ItemType, ReturnType]):
         pass
 
     @retry(**SERVICE_MODEL_RETRY_POLICY)
-    async def _predict(self, item):
+    async def _predict(self, item, **kwargs):
         if self.aiohttp_session is None:
             self.aiohttp_session = aiohttp.ClientSession()
         async with self.aiohttp_session.post(
@@ -79,7 +79,7 @@ class DistantHTTPModel(Model[ItemType, ReturnType]):
         pass
 
     @retry(**SERVICE_MODEL_RETRY_POLICY)
-    def _predict(self, item):
+    def _predict(self, item, **kwargs):
         if not self.requests_session:
             self.requests_session = requests.Session()
         response = self.requests_session.post(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_model": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     class ItemModel(pydantic.BaseModel):
@@ -42,19 +42,19 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_complex_model": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return {"sorted": "".join(sorted(item.string))}
 
     class NotValidatedModel(Model):
         CONFIGURATIONS = {"unvalidated_model": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     class ValidationNotSupported(Model[np.ndarray, np.ndarray]):
         CONFIGURATIONS = {"no_supported_model": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     class SomeAsset(Asset):
@@ -64,7 +64,7 @@ def api_no_type(event_loop):
 
         CONFIGURATIONS = {"some_asset": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return {"sorted": "".join(sorted(item.string))}
 
     router = ModelkitAutoAPIRouter(

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -63,14 +63,14 @@ async def test_compose_async_sync_async(event_loop):
     class SomeAsyncModel(AsyncModel):
         CONFIGURATIONS = {"async_model": {}}
 
-        async def _predict(self, item):
+        async def _predict(self, item, **_):
             await asyncio.sleep(0)
             return item
 
     class ComposedModel(Model):
         CONFIGURATIONS = {"composed_model": {"model_dependencies": {"async_model"}}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return self.model_dependencies["async_model"].predict(item)
 
     class SomeAsyncComposedModel(AsyncModel):
@@ -78,7 +78,7 @@ async def test_compose_async_sync_async(event_loop):
             "async_composed_model": {"model_dependencies": {"composed_model"}}
         }
 
-        async def _predict(self, item):
+        async def _predict(self, item, **_):
             await asyncio.sleep(0)
             return await self.model_dependencies["composed_model"].predict(item)
 

--- a/tests/test_auto_testing.py
+++ b/tests/test_auto_testing.py
@@ -26,7 +26,7 @@ class TestableModel(Model[ModelItemType, ModelItemType]):
         ]
     }
 
-    def _predict(self, item, add_one=False):
+    def _predict(self, item, add_one=False, **_):
         if add_one:
             return {"x": item.x + 1}
         return item
@@ -40,7 +40,7 @@ def test_list_cases():
             cases=[{"item": {"x": 1}, "result": {"x": 1}}]
         )
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     assert list(SomeModel._iterate_test_cases()) == [
@@ -52,7 +52,7 @@ def test_list_cases():
 
         TEST_CASES = {"cases": [{"item": {"x": 1}, "result": {"x": 1}}]}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     assert list(TestableModel._iterate_test_cases()) == [

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -5,11 +5,11 @@ import pytest
 from modelkit.core.model import AsyncModel, Model
 
 
-def _identity(x):
+def _identity(x, **_):
     return x
 
 
-def _double(x):
+def _double(x, **_):
     return [y * 2 for y in x]
 
 
@@ -54,7 +54,7 @@ def test_callback_batch_process(
 ):
     steps = 0
 
-    def func(items):
+    def func(items, **_):
         return [item + 1 for item in items]
 
     def _callback(batch_step, batch_items, batch_results):
@@ -94,7 +94,7 @@ async def test_callback_batch_process_async(
     steps = 0
 
     class SomeAsyncModel(AsyncModel):
-        async def _predict_batch(self, items):
+        async def _predict_batch(self, items, **_):
             await asyncio.sleep(0)
             return [item + 1 for item in items]
 
@@ -143,7 +143,7 @@ def _do_gen_test(m, batch_size, n_items):
 
 def test_predict_gen():
     class GeneratorTestModel(Model):
-        def _predict_batch(self, items):
+        def _predict_batch(self, items, **_):
             # returns the size of the batch
             return [
                 (item, position_in_batch, len(items))
@@ -175,7 +175,7 @@ async def _do_gen_test_async(m, batch_size, n_items):
 @pytest.mark.asyncio
 async def test_predict_gen_async():
     class AsyncGeneratorTestModel(AsyncModel):
-        async def _predict_batch(self, items):
+        async def _predict_batch(self, items, **_):
             await asyncio.sleep(0)
             # returns the size of the batch
             return [

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -19,7 +19,7 @@ def test_native_cache(cache_implementation):
     class SomeModel(Model):
         CONFIGURATIONS = {"model": {"model_settings": {"cache_predictions": True}}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     class SomeModelMultiple(Model):
@@ -27,7 +27,7 @@ def test_native_cache(cache_implementation):
             "model_multiple": {"model_settings": {"cache_predictions": True}}
         }
 
-        def _predict_batch(self, items):
+        def _predict_batch(self, items, **_):
             return items
 
     class Item(pydantic.BaseModel):
@@ -41,7 +41,7 @@ def test_native_cache(cache_implementation):
             "model_validated": {"model_settings": {"cache_predictions": True}}
         }
 
-        def _predict_batch(self, items):
+        def _predict_batch(self, items, **_):
             return items
 
     svc = ModelLibrary(
@@ -114,7 +114,7 @@ def test_redis_cache(redis_service):
     class SomeModel(Model):
         CONFIGURATIONS = {"model": {"model_settings": {"cache_predictions": True}}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     class SomeModelMultiple(Model):
@@ -122,7 +122,7 @@ def test_redis_cache(redis_service):
             "model_multiple": {"model_settings": {"cache_predictions": True}}
         }
 
-        def _predict_batch(self, items):
+        def _predict_batch(self, items, **_):
             return items
 
     class Item(pydantic.BaseModel):
@@ -136,7 +136,7 @@ def test_redis_cache(redis_service):
             "model_validated": {"model_settings": {"cache_predictions": True}}
         }
 
-        def _predict_batch(self, items):
+        def _predict_batch(self, items, **_):
             return items
 
     svc = ModelLibrary(
@@ -176,7 +176,7 @@ async def test_redis_cache_async(redis_service, event_loop):
     class SomeModel(AsyncModel):
         CONFIGURATIONS = {"model": {"model_settings": {"cache_predictions": True}}}
 
-        async def _predict(self, item):
+        async def _predict(self, item, **_):
             await asyncio.sleep(0)
             return item
 
@@ -185,7 +185,7 @@ async def test_redis_cache_async(redis_service, event_loop):
             "model_multiple": {"model_settings": {"cache_predictions": True}}
         }
 
-        async def _predict_batch(self, items):
+        async def _predict_batch(self, items, **_):
             await asyncio.sleep(0)
             return items
 
@@ -200,7 +200,7 @@ async def test_redis_cache_async(redis_service, event_loop):
             "model_validated": {"model_settings": {"cache_predictions": True}}
         }
 
-        async def _predict_batch(self, items):
+        async def _predict_batch(self, items, **_):
             await asyncio.sleep(0)
             return items
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -210,7 +210,7 @@ def test_lazy_loading_dependencies():
         def _load(self):
             self.some_attribute = self.model_dependencies["model0"].some_attribute
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return self.some_attribute
 
     p = ModelLibrary(models=[Model1, Model0], settings={"lazy_loading": True})
@@ -317,7 +317,7 @@ def test_load_model():
     class SomeModel(Model):
         CONFIGURATIONS = {"model": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     m = load_model("model", models=SomeModel)
@@ -379,13 +379,13 @@ def test_rename_dependencies():
     class SomeModel(Model):
         CONFIGURATIONS = {"ok": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return self.configuration_key
 
     class SomeModel2(Model):
         CONFIGURATIONS = {"boomer": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return self.configuration_key
 
     class FinalModel(Model):
@@ -398,7 +398,7 @@ def test_rename_dependencies():
             },
         }
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return self.model_dependencies["ok"](item)
 
     svc = ModelLibrary(models=[SomeModel, SomeModel2, FinalModel])
@@ -487,7 +487,7 @@ def test_auto_load():
         def _load(self):
             self.some_attribute = "OK"
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return self.some_attribute
 
     m = SomeModel()
@@ -497,7 +497,7 @@ def test_auto_load():
         def _load(self):
             self.some_attribute = self.model_dependencies["model"].some_attribute
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return self.some_attribute
 
     m = SomeModelDep(model_dependencies={"model": SomeModel()})

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -20,7 +20,7 @@ def test_describe():
 
         CONFIGURATIONS = {"some_model_a": {}}
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     class ItemModel(pydantic.BaseModel):
@@ -47,7 +47,7 @@ def test_describe():
             super().__init__(*args, **kwargs)
             self.some_object = A()
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     library = ModelLibrary(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,17 +8,17 @@ class CustomError(BaseException):
 
 
 class OKModel(Model):
-    def _predict(self, item):
+    def _predict(self, item, **_):
         return self.model_dependencies["error_model"].predict(item)
 
 
 class ErrorModel(Model):
-    def _predict(self, item):
+    def _predict(self, item, **_):
         raise CustomError("something went wrong")
 
 
 class ErrorBatchModel(Model):
-    def _predict_batch(self, item):
+    def _predict_batch(self, item, **_):
         raise CustomError("something went wrong")
 
 
@@ -72,17 +72,17 @@ def test_prediction_error_complex_tb(monkeypatch, model):
 
 
 class AsyncOKModel(AsyncModel):
-    async def _predict(self, item):
+    async def _predict(self, item, **_):
         return self.model_dependencies["error_model"].predict(item)
 
 
 class AsyncErrorModel(AsyncModel):
-    async def _predict(self, item):
+    async def _predict(self, item, **_):
         raise CustomError("something went wrong")
 
 
 class AsyncErrorBatchModel(AsyncModel):
-    async def _predict_batch(self, item):
+    async def _predict_batch(self, item, **_):
         raise CustomError("something went wrong")
 
 

--- a/tests/test_model_serialization.py
+++ b/tests/test_model_serialization.py
@@ -14,7 +14,7 @@ class ReturnType(pydantic.BaseModel):
 
 
 class SomeModel(Model[ItemType, ReturnType]):
-    def _predict(self, item):
+    def _predict(self, item, **_):
         return item
 
 
@@ -27,7 +27,7 @@ def test_model_serialization():
 
 
 class SomeModelWithoutTypes(Model):
-    def _predict(self, item):
+    def _predict(self, item, **_):
         return item
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -24,7 +24,7 @@ def test_validate_item_spec_pydantic(service_settings):
         x: int
 
     class SomeValidatedModel(Model[ItemModel, Any]):
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     valid_test_item = {"x": 10}
@@ -89,7 +89,7 @@ def test_validate_item_spec_pydantic_default(service_settings):
 )
 def test_validate_item_spec_typing(service_settings):
     class SomeValidatedModel(Model[Dict[str, int], Any]):
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     valid_test_item = {"x": 10}
@@ -126,7 +126,7 @@ def test_validate_return_spec(service_settings):
         x: int
 
     class SomeValidatedModel(Model[Any, ItemModel]):
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     m = SomeValidatedModel(service_settings)
@@ -154,7 +154,7 @@ def test_validate_list_items(service_settings):
             self.counter = 0
             super().__init__(*args, **kwargs)
 
-        def _predict(self, item):
+        def _predict(self, item, **_):
             self.counter += 1
             return item
 
@@ -174,7 +174,7 @@ def test_validate_list_items(service_settings):
 )
 def test_validate_none(service_settings):
     class SomeValidatedModel(Model):
-        def _predict(self, item):
+        def _predict(self, item, **_):
             return item
 
     m = SomeValidatedModel(service_settings=service_settings)


### PR DESCRIPTION
In order to be aware of the batch_size from within the _predict_batch method.
E.g. we might find relevant to pass the batch size to spacy and the nlp.pipe method:

```
nlp.pipe(texts, batch_size=batch_size)
```