### PR TITLE
Moar types

### DIFF
--- a/docs/library/special/tensorflow.md
+++ b/docs/library/special/tensorflow.md
@@ -129,7 +129,7 @@ Several environment variables control how `modelkit` requests predictions from T
 All of these parameters can be set programmatically (and passed to the `ModelLibrary`'s settings):
 
 ```python
-svc_serving_grpc = ModelLibrary(
+lib_serving_grpc = ModelLibrary(
     required_models=...,
     settings=LibrarySettings(
         tf_serving={

--- a/docs/library/testing.md
+++ b/docs/library/testing.md
@@ -12,15 +12,15 @@ The belief is that test cases for models constitute essential documentation for 
 from modelkit.core.fixtures import make_modellibrary_test
 
 make_modellibrary_test(
-    **prediction_service_arguments, # insert any arguments to ModelLibrary here
-    fixture_name="testing_prediction_service",
-    test_name="test_auto_prediction_service",
+    **model_library_arguments, # insert any arguments to ModelLibrary here
+    fixture_name="testing_model_library",
+    test_name="test_auto_model_library",
 )
 ```
 
-This will create a pytest fixture called `testing_prediction_service` that returns `ModelLibrary(**prediction_service_arguments)` which you can freely reuse.
+This will create a pytest fixture called `testing_model_library` that returns `ModelLibrary(**model_library_arguments)` which you can freely reuse.
 
-In addition, it creates a test called `test_auto_prediction_service` that iterates through the tests defined as part of `Model` classes.
+In addition, it creates a test called `test_auto_model_library` that iterates through the tests defined as part of `Model` classes.
 
 
 ### Defining test cases
@@ -47,9 +47,9 @@ Each test is instantiated with an item value and a result value, the automatic t
 
 ```python
 @pytest.mark.parametrize("model_key, item, result", [case for case in Model.TEST_CASES])
-def test_function(model_key, item, result, testing_prediction_service):
-    svc = testing_prediction_service.getfixturevalue(fixture_name)
-    assert svc.get(model_key)(item) == result
+def test_function(model_key, item, result, testing_model_library):
+    lib = testing_model_library.getfixturevalue(fixture_name)
+    assert lib.get(model_key)(item) == result
 
 ```
 

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -1,17 +1,14 @@
-from types import ModuleType
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Union
 
 import fastapi
 from rich.console import Console
 from structlog import get_logger
 
 from modelkit.core.library import LibrarySettings, ModelConfiguration, ModelLibrary
-from modelkit.core.model import AsyncModel, BaseModel
+from modelkit.core.model import AsyncModel
+from modelkit.core.types import LibraryModelsType
 
 logger = get_logger(__name__)
-
-# create APIRoute for model
-# create startup event
 
 
 class ModelkitAPIRouter(fastapi.APIRouter):
@@ -23,7 +20,7 @@ class ModelkitAPIRouter(fastapi.APIRouter):
         configuration: Optional[
             Dict[str, Union[Dict[str, Any], ModelConfiguration]]
         ] = None,
-        models: Optional[Union[ModuleType, Type, List]] = None,
+        models: Optional[LibraryModelsType] = None,
         required_models: Optional[Union[List[str], Dict[str, Any]]] = None,
         # APIRouter arguments
         **kwargs,
@@ -59,7 +56,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
         configuration: Optional[
             Dict[str, Union[Dict[str, Any], ModelConfiguration]]
         ] = None,
-        models: Optional[Union[ModuleType, Type, List]] = None,
+        models: Optional[LibraryModelsType] = None,
         # paths overrides change the configuration key into a path
         route_paths: Optional[Dict[str, str]] = None,
         # APIRouter arguments

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -5,7 +5,7 @@ from rich.console import Console
 from structlog import get_logger
 
 from modelkit.core.library import LibrarySettings, ModelConfiguration, ModelLibrary
-from modelkit.core.model import AsyncModel
+from modelkit.core.model import AsyncModel, BaseModel
 from modelkit.core.types import LibraryModelsType
 
 logger = get_logger(__name__)

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 class ModelkitAPIRouter(fastapi.APIRouter):
     def __init__(
         self,
-        # PredictionService arguments
+        # ModelLibrary arguments
         settings: Optional[Union[Dict, LibrarySettings]] = None,
         assetsmanager_settings: Optional[dict] = None,
         configuration: Optional[
@@ -49,7 +49,7 @@ class ModelkitAPIRouter(fastapi.APIRouter):
 class ModelkitAutoAPIRouter(ModelkitAPIRouter):
     def __init__(
         self,
-        # PredictionService arguments
+        # ModelLibrary arguments
         required_models: Optional[List[str]] = None,
         settings: Optional[Union[Dict, LibrarySettings]] = None,
         assetsmanager_settings: Optional[dict] = None,

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -34,7 +34,7 @@ class ModelkitAPIRouter(fastapi.APIRouter):
         kwargs["on_shutdown"] = on_shutdown
         super().__init__(**kwargs)
 
-        self.svc = ModelLibrary(
+        self.lib = ModelLibrary(
             required_models=required_models,
             settings=settings,
             assetsmanager_settings=assetsmanager_settings,
@@ -43,7 +43,7 @@ class ModelkitAPIRouter(fastapi.APIRouter):
         )
 
     async def _on_shutdown(self):
-        await self.svc.aclose()
+        await self.lib.aclose()
 
 
 class ModelkitAutoAPIRouter(ModelkitAPIRouter):
@@ -72,8 +72,8 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
         )
 
         route_paths = route_paths or {}
-        for model_name in self.svc.required_models:
-            m: AbstractModel = self.svc.get(model_name)
+        for model_name in self.lib.required_models:
+            m: AbstractModel = self.lib.get(model_name)
             if not isinstance(m, AbstractModel):
                 continue
             path = route_paths.get(model_name, "/predict/" + model_name)
@@ -128,7 +128,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
             async def _aendpoint(
                 item: item_type = fastapi.Body(...),
-                model=fastapi.Depends(lambda: self.svc.get(model_name)),
+                model=fastapi.Depends(lambda: self.lib.get(model_name)),
             ):  # noqa: B008
                 return await model.predict(item)
 
@@ -136,7 +136,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
         def _endpoint(
             item: item_type = fastapi.Body(...),
-            model=fastapi.Depends(lambda: self.svc.get(model_name)),
+            model=fastapi.Depends(lambda: self.lib.get(model_name)),
         ):  # noqa: B008
             return model.predict(item)
 
@@ -147,7 +147,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
             async def _aendpoint(
                 item: item_type = fastapi.Body(...),
-                model=fastapi.Depends(lambda: self.svc.get(model_name)),
+                model=fastapi.Depends(lambda: self.lib.get(model_name)),
             ):  # noqa: B008
                 return await model.predict_batch(item)
 
@@ -155,7 +155,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
         def _endpoint(
             item: List[item_type] = fastapi.Body(...),
-            model=fastapi.Depends(lambda: self.svc.get(model_name)),
+            model=fastapi.Depends(lambda: self.lib.get(model_name)),
         ):  # noqa: B008
             return model.predict_batch(item)
 

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -5,7 +5,7 @@ from rich.console import Console
 from structlog import get_logger
 
 from modelkit.core.library import LibrarySettings, ModelConfiguration, ModelLibrary
-from modelkit.core.model import AsyncModel, BaseModel
+from modelkit.core.model import AbstractModel, AsyncModel
 from modelkit.core.types import LibraryModelsType
 
 logger = get_logger(__name__)
@@ -73,8 +73,8 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
         route_paths = route_paths or {}
         for model_name in self.svc.required_models:
-            m: BaseModel = self.svc.get(model_name)
-            if not isinstance(m, BaseModel):
+            m: AbstractModel = self.svc.get(model_name)
+            if not isinstance(m, AbstractModel):
                 continue
             path = route_paths.get(model_name, "/predict/" + model_name)
             batch_path = route_paths.get(model_name, "/predict/batch/" + model_name)

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -95,9 +95,9 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
             logger.info("Adding model", name=model_name)
             try:
-                item_type = m.item_type if hasattr(m, "item_type") else Any
+                item_type = m._item_type or Any
                 try:
-                    item_type.schema()
+                    item_type.schema()  # type: ignore
                 except (ValueError, AttributeError):
                     item_type = Any
 

--- a/modelkit/cli.py
+++ b/modelkit/cli.py
@@ -250,8 +250,8 @@ def predict(model_name, models):
     """
     Make predictions for a given model.
     """
-    svc = _configure_from_cli_arguments(models, [model_name], False, {})
-    model = svc.get(model_name)
+    lib = _configure_from_cli_arguments(models, [model_name], False, {})
+    model = lib.get(model_name)
     while True:
         r = click.prompt(f"[{model_name}]>")
         if r:

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -84,18 +84,20 @@ class ModelLibrary:
         """
         if isinstance(settings, dict):
             settings = LibrarySettings(**settings)
-        self.settings = settings or LibrarySettings()
-        self.assetsmanager_settings = assetsmanager_settings or {}
-        self._override_assets_manager = None
-        self._lazy_loading = self.settings.lazy_loading
+        self.settings: LibrarySettings = settings or LibrarySettings()
+        self.assetsmanager_settings: Dict[str, Any] = assetsmanager_settings or {}
+        self._override_assets_manager: Optional[AssetsManager] = None
+        self._lazy_loading: bool = self.settings.lazy_loading
         if models is None:
             models = os.environ.get("MODELKIT_DEFAULT_PACKAGE")
-        self.configuration = configure(models=models, configuration=configuration)
+        self.configuration: Dict[str, ModelConfiguration] = configure(
+            models=models, configuration=configuration
+        )
         self.models: Dict[str, Asset] = {}
         self.assets_info: Dict[str, AssetInfo] = {}
         self._asset_manager: Optional[AssetsManager] = None
 
-        self.required_models = (
+        self.required_models: Dict[str, Dict[str, Any]] = (
             required_models
             if required_models is not None
             else {r: {} for r in self.configuration}
@@ -368,7 +370,7 @@ class ModelLibrary:
         model_types = {type(model_type) for model_type in self._models.values()}
         for model_type in model_types:
             for model_key, item, result in model_type._iterate_test_cases():
-                if model_key in self._models:
+                if model_key in self.models:
                     yield self.get(model_key), item, result
 
     def describe(self, console=None) -> None:

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -7,7 +7,6 @@ import collections
 import copy
 import os
 import re
-from types import ModuleType
 from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, Union, cast
 
 import humanize
@@ -23,6 +22,7 @@ from modelkit.assets.settings import AssetSpec
 from modelkit.core.model import AsyncModel, Model
 from modelkit.core.model_configuration import ModelConfiguration, configure, list_assets
 from modelkit.core.settings import LibrarySettings, NativeCacheSettings, RedisSettings
+from modelkit.core.types import LibraryModelsType
 from modelkit.utils.cache import Cache, NativeCache, RedisCache
 from modelkit.utils.memory import PerformanceTracker
 from modelkit.utils.pretty import describe
@@ -51,7 +51,7 @@ class ModelLibrary:
         configuration: Optional[
             Dict[str, Union[Dict[str, Any], ModelConfiguration]]
         ] = None,
-        models: Optional[Union[ModuleType, Type, List, str]] = None,
+        models: Optional[LibraryModelsType] = None,
         required_models: Optional[Union[List[str], Dict[str, Any]]] = None,
     ):
         """
@@ -377,7 +377,7 @@ def load_model(
     configuration: Optional[
         Dict[str, Union[Dict[str, Any], ModelConfiguration]]
     ] = None,
-    models: Optional[Union[ModuleType, Type, List]] = None,
+    models: Optional[LibraryModelsType] = None,
 ):
     """
     Loads an modelkit model without the need for a ModelLibrary.
@@ -398,7 +398,7 @@ def download_assets(
     configuration: Optional[
         Mapping[str, Union[Dict[str, Any], ModelConfiguration]]
     ] = None,
-    models: Optional[Union[ModuleType, Type, List]] = None,
+    models: Optional[LibraryModelsType] = None,
     required_models: Optional[List[str]] = None,
 ):
     assetsmanager_settings = assetsmanager_settings or {}

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -19,7 +19,7 @@ from structlog import get_logger
 import modelkit.assets
 from modelkit.assets.manager import AssetsManager
 from modelkit.assets.settings import AssetSpec
-from modelkit.core.model import AsyncModel, Model
+from modelkit.core.model import Asset, AsyncModel, Model
 from modelkit.core.model_configuration import ModelConfiguration, configure, list_assets
 from modelkit.core.settings import LibrarySettings, NativeCacheSettings, RedisSettings
 from modelkit.core.types import LibraryModelsType
@@ -73,9 +73,9 @@ class ModelLibrary:
         if models is None:
             models = os.environ.get("MODELKIT_DEFAULT_PACKAGE")
         self.configuration = configure(models=models, configuration=configuration)
-        self.models: Dict[str, Model] = {}
+        self.models: Dict[str, Asset] = {}
         self.assets_info: Dict[str, Dict[str, str]] = {}
-        self._asset_manager = None
+        self._asset_manager: Optional[AssetsManager] = None
 
         self.required_models = (
             required_models

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -407,13 +407,13 @@ def load_model(
     This is useful for development, and should be avoided in production
     code.
     """
-    svc = ModelLibrary(
+    lib = ModelLibrary(
         required_models=[model_name],
         models=models,
         configuration=configuration,
         settings={"lazy_loading": True},
     )
-    return svc.get(model_name, model_type=model_type)
+    return lib.get(model_name, model_type=model_type)
 
 
 def download_assets(

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -398,7 +398,8 @@ def load_model(
         Dict[str, Union[Dict[str, Any], ModelConfiguration]]
     ] = None,
     models: Optional[LibraryModelsType] = None,
-):
+    model_type: Optional[Type[T]] = None,
+) -> T:
     """
     Loads an modelkit model without the need for a ModelLibrary.
     This is useful for development, and should be avoided in production
@@ -410,7 +411,7 @@ def load_model(
         configuration=configuration,
         settings={"lazy_loading": True},
     )
-    return svc.get(model_name)
+    return svc.get(model_name, model_type=model_type)
 
 
 def download_assets(

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -97,14 +97,14 @@ class ModelLibrary:
         self.assets_info: Dict[str, AssetInfo] = {}
         self._asset_manager: Optional[AssetsManager] = None
 
-        self.required_models: Dict[str, Dict[str, Any]] = (
+        required_models = (
             required_models
             if required_models is not None
             else {r: {} for r in self.configuration}
         )
-        if isinstance(self.required_models, list):
-            self.required_models = {r: {} for r in self.required_models}
-
+        if isinstance(required_models, list):
+            required_models = {r: {} for r in required_models}
+        self.required_models: Dict[str, Dict[str, Any]] = required_models
         self.cache: Optional[Cache] = None
         if self.settings.cache:
             if isinstance(self.settings.cache, RedisSettings):

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -371,7 +371,7 @@ class ModelLibrary:
                 if model_key in self._models:
                     yield self.get(model_key), item, result
 
-    def describe(self, console=None):
+    def describe(self, console=None) -> None:
         if not console:
             console = Console()
         t = Tree("[bold]Settings")

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -64,8 +64,8 @@ class Asset:
         self.cache: Optional[Cache] = kwargs.pop("cache", None)
         self._loaded: bool = False
         self.model_settings: Dict[str, Any] = kwargs.pop("model_settings", {})
-        self.load_time: float = None
-        self.load_memory_increment: float = None
+        self._load_time: float = None
+        self._load_memory_increment: float = None
         if not self.service_settings.lazy_loading:
             self.load()
 
@@ -87,8 +87,8 @@ class Asset:
             memory_bytes=m.increment,
         )
         self._loaded = True
-        self.load_time = m.time
-        self.load_memory_increment = m.increment
+        self._load_time = m.time
+        self._load_memory_increment = m.increment
 
     def _load(self):
         pass
@@ -281,16 +281,16 @@ class BaseModel(Asset, Generic[ItemType, ReturnType]):
                 f" {pretty_print_type(self.item_type)}"
             )
 
-        if self.load_time:
+        if self._load_time:
             sub_t = t.add(
                 "[deep_sky_blue1]load time[/deep_sky_blue1]: [orange3]"
-                + humanize.naturaldelta(self.load_time, minimum_unit="microseconds")
+                + humanize.naturaldelta(self._load_time, minimum_unit="microseconds")
             )
 
-        if self.load_memory_increment is not None:
+        if self._load_memory_increment is not None:
             sub_t = t.add(
                 f"[deep_sky_blue1]load memory[/deep_sky_blue1]: "
-                f"[orange3]{humanize.naturalsize(self.load_memory_increment)}"
+                f"[orange3]{humanize.naturalsize(self._load_memory_increment)}"
             )
         if self.model_dependencies:
             dep_t = t.add("[deep_sky_blue1]dependencies")

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -69,7 +69,7 @@ class Asset:
         if not self.service_settings.lazy_loading:
             self.load()
 
-    def load(self):
+    def load(self) -> None:
         """Implement this method in order for the model to load and
         deserialize its asset, whose path is kept int the `asset_path`
         attribute"""
@@ -90,7 +90,7 @@ class Asset:
         self._load_time = m.time
         self._load_memory_increment = m.increment
 
-    def _load(self):
+    def _load(self) -> None:
         pass
 
 
@@ -108,9 +108,9 @@ PYDANTIC_ERROR_TRUNCATION = 20
 class ModelkitDataValidationException(Exception):
     def __init__(
         self,
-        model_identifier,
-        pydantic_exc=None,
-        error_str="Data validation error in model",
+        model_identifier: str,
+        pydantic_exc: pydantic.error_wrappers.ValidationError,
+        error_str: str = "Data validation error in model",
     ):
         pydantic_exc_output = ""
         if pydantic_exc:
@@ -707,7 +707,7 @@ class WrappedAsyncModel:
         self.async_model = async_model
         self.predict = AsyncToSync(self.async_model.predict)
         self.predict_batch = AsyncToSync(self.async_model.predict_batch)
-        self._loaded : bool = True
+        self._loaded: bool = True
         # The following does not currently work, because AsyncToSync does not
         # seem to correctly wrap asynchronous generators
         # self.predict_gen = AsyncToSync(self.async_model.predict_gen)

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -69,8 +69,8 @@ class Asset:
         self.asset_path: str = asset_path
         self.cache: Optional[Cache] = cache
         self.model_settings: Dict[str, Any] = model_settings or {}
-        self.batch_size: Optional[int] = batch_size or model_settings.get(
-            "batch_size", None
+        self.batch_size: Optional[int] = batch_size or self.model_settings.get(
+            "batch_size"
         )
         self.model_dependencies: Dict[
             str, Union[Model, AsyncModel, WrappedAsyncModel]

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -50,6 +50,7 @@ class Asset:
         model_settings: Optional[Dict[str, Any]] = None,
         asset_path: str = "",
         cache: Optional[Cache] = None,
+        batch_size: Optional[int] = None,
         model_dependencies: Optional[
             Dict[str, Union["Model", "AsyncModel", "WrappedAsyncModel"]]
         ] = None,
@@ -68,7 +69,9 @@ class Asset:
         self.asset_path: str = asset_path
         self.cache: Optional[Cache] = cache
         self.model_settings: Dict[str, Any] = model_settings or {}
-        self.batch_size: Optional[int] = self.model_settings.get("batch_size", None)
+        self.batch_size: Optional[int] = batch_size or model_settings.get(
+            "batch_size", None
+        )
         self.model_dependencies: Dict[
             str, Union[Model, AsyncModel, WrappedAsyncModel]
         ] = (model_dependencies or {})

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -169,7 +169,7 @@ class ItemValidationException(ModelkitDataValidationException):
         )
 
 
-class BaseModel(Asset, Generic[ItemType, ReturnType]):
+class AbstractModel(Asset, Generic[ItemType, ReturnType]):
     """
     Model
     ===
@@ -375,7 +375,7 @@ class BaseModel(Asset, Generic[ItemType, ReturnType]):
                 raise
 
 
-class Model(BaseModel[ItemType, ReturnType]):
+class Model(AbstractModel[ItemType, ReturnType]):
     def load(self):
         super().load()
         try:
@@ -554,7 +554,7 @@ class Model(BaseModel[ItemType, ReturnType]):
         pass
 
 
-class AsyncModel(BaseModel[ItemType, ReturnType]):
+class AsyncModel(AbstractModel[ItemType, ReturnType]):
     async def _predict(self, item: ItemType, **kwargs) -> ReturnType:
         result = await self._predict_batch([item], **kwargs)
         return result[0]

--- a/modelkit/core/model_configuration.py
+++ b/modelkit/core/model_configuration.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Mapping, Optional, Set, Type, Union
 import pydantic
 
 from modelkit.core.model import Asset
+from modelkit.core.types import LibraryModelsType
 
 
 class ModelConfiguration(pydantic.BaseSettings):
@@ -70,7 +71,7 @@ def _configurations_from_objects(m) -> Dict[str, ModelConfiguration]:
 
 
 def configure(
-    models: Optional[Union[ModuleType, Type, List, str]] = None,
+    models: Optional[LibraryModelsType] = None,
     configuration: Optional[
         Mapping[str, Union[Dict[str, Any], ModelConfiguration]]
     ] = None,
@@ -99,7 +100,7 @@ def configure(
 
 
 def list_assets(
-    models: Optional[Union[ModuleType, Type, List]] = None,
+    models: Optional[LibraryModelsType] = None,
     required_models: Optional[List[str]] = None,
     configuration: Optional[
         Mapping[str, Union[Dict[str, Any], ModelConfiguration]]

--- a/modelkit/core/models/distant_model.py
+++ b/modelkit/core/models/distant_model.py
@@ -47,8 +47,8 @@ SERVICE_MODEL_RETRY_POLICY = {
 
 
 class AsyncDistantHTTPModel(AsyncModel[ItemType, ReturnType]):
-    def __init__(self, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.endpoint = self.model_settings["endpoint"]
         self.aiohttp_session: Optional[aiohttp.ClientSession] = None
 
@@ -75,8 +75,8 @@ class AsyncDistantHTTPModel(AsyncModel[ItemType, ReturnType]):
 
 
 class DistantHTTPModel(Model[ItemType, ReturnType]):
-    def __init__(self, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.endpoint = self.model_settings["endpoint"]
         self.requests_session: Optional[requests.Session] = None
 

--- a/modelkit/core/models/tensorflow_model.py
+++ b/modelkit/core/models/tensorflow_model.py
@@ -47,8 +47,8 @@ def safe_np_dump(obj):
 
 
 class TensorflowModel(Model[ItemType, ReturnType]):
-    def __init__(self, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         output_tensor_mapping = kwargs.pop("output_tensor_mapping", {}) or kwargs[
             "model_settings"
         ].get("output_tensor_mapping")
@@ -205,13 +205,12 @@ class TensorflowModel(Model[ItemType, ReturnType]):
 
 
 class AsyncTensorflowModel(AsyncModel[ItemType, ReturnType]):
-    def __init__(self, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
+    def __init__(self, **kwargs):
         output_tensor_mapping = kwargs.pop("output_tensor_mapping", {}) or kwargs[
             "model_settings"
         ].get("output_tensor_mapping")
         self.output_tensor_mapping = output_tensor_mapping
-        self.output_shapes = kwargs.get("output_shapes", {}) or kwargs[
+        self.output_shapes = kwargs.pop("output_shapes", {}) or kwargs[
             "model_settings"
         ].get("output_shapes")
         self.output_dtypes = kwargs.pop(
@@ -227,6 +226,8 @@ class AsyncTensorflowModel(AsyncModel[ItemType, ReturnType]):
         )
         # the GRPC stub
         self.grpc_stub = None
+
+        super().__init__(**kwargs)
 
         connect_tf_serving(
             self.tf_model_name,

--- a/modelkit/core/models/tensorflow_model.py
+++ b/modelkit/core/models/tensorflow_model.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import aiohttp
 import numpy as np
@@ -32,6 +32,7 @@ try:
     from tensorflow_serving.apis import prediction_service_pb2_grpc
     from tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataRequest
     from tensorflow_serving.apis.predict_pb2 import PredictRequest
+
 except ModuleNotFoundError:
     logger.info("Tensorflow serving is not installed")
 
@@ -47,28 +48,40 @@ def safe_np_dump(obj):
 
 
 class TensorflowModel(Model[ItemType, ReturnType]):
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        output_tensor_mapping: Optional[Dict[str, str]] = None,
+        output_shapes: Optional[Dict[str, Tuple]] = None,
+        output_dtypes: Optional[Dict[str, np.dtype]] = None,
+        tf_model_name: Optional[str] = None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
-        output_tensor_mapping = kwargs.pop("output_tensor_mapping", {}) or kwargs[
+        self.output_tensor_mapping = output_tensor_mapping or kwargs[
             "model_settings"
         ].get("output_tensor_mapping")
-        self.output_tensor_mapping = output_tensor_mapping
-        self.output_shapes = kwargs.get("output_shapes", {}) or kwargs[
-            "model_settings"
-        ].get("output_shapes")
-        self.output_dtypes = kwargs.pop(
-            "output_dtypes", {name: np.float for name in output_tensor_mapping}
-        ) or kwargs["model_settings"].get("output_dtypes")
+        self.output_shapes = output_shapes or kwargs["model_settings"].get(
+            "output_shapes"
+        )
+        self.output_dtypes = (
+            output_dtypes
+            or kwargs["model_settings"].get("output_dtypes")
+            or {name: np.float for name in self.output_tensor_mapping}
+        )
         # sanity checks
-        assert output_tensor_mapping.keys() == self.output_dtypes.keys()
-        assert output_tensor_mapping.keys() == self.output_shapes.keys()
+        assert self.output_tensor_mapping.keys() == self.output_dtypes.keys()
+        assert self.output_tensor_mapping.keys() == self.output_shapes.keys()
 
         self.tf_model_name = (
-            kwargs.pop("model_settings", {}).get("tf_model_name")
+            tf_model_name
+            or kwargs.get("model_settings", {}).get("tf_model_name")
             or self.configuration_key
         )
+
         # the GRPC stub
-        self.grpc_stub = None
+        self.grpc_stub: Optional[
+            prediction_service_pb2_grpc.PredictionServiceStub
+        ] = None
 
         # the session (for use with TF as an API)
         self.session = None
@@ -122,6 +135,12 @@ class TensorflowModel(Model[ItemType, ReturnType]):
         for key, vect in vects.items():
             request.inputs[key].CopyFrom(
                 tf.compat.v1.make_tensor_proto(vect, dtype=dtype)
+            )
+        if not self.grpc_stub:
+            self.grpc_stub = connect_tf_serving_grpc(
+                self.tf_model_name,
+                self.service_settings.tf_serving.host,
+                self.service_settings.tf_serving.port,
             )
 
         r = self.grpc_stub.Predict(request, 1)
@@ -205,29 +224,35 @@ class TensorflowModel(Model[ItemType, ReturnType]):
 
 
 class AsyncTensorflowModel(AsyncModel[ItemType, ReturnType]):
-    def __init__(self, **kwargs):
-        output_tensor_mapping = kwargs.pop("output_tensor_mapping", {}) or kwargs[
+    def __init__(
+        self,
+        output_tensor_mapping: Optional[Dict[str, str]] = None,
+        output_shapes: Optional[Dict[str, Tuple]] = None,
+        output_dtypes: Optional[Dict[str, np.dtype]] = None,
+        tf_model_name: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.output_tensor_mapping = output_tensor_mapping or kwargs[
             "model_settings"
         ].get("output_tensor_mapping")
-        self.output_tensor_mapping = output_tensor_mapping
-        self.output_shapes = kwargs.pop("output_shapes", {}) or kwargs[
-            "model_settings"
-        ].get("output_shapes")
-        self.output_dtypes = kwargs.pop(
-            "output_dtypes", {name: np.float for name in output_tensor_mapping}
-        ) or kwargs["model_settings"].get("output_dtypes")
+        self.output_shapes = output_shapes or kwargs["model_settings"].get(
+            "output_shapes"
+        )
+        self.output_dtypes = (
+            output_dtypes
+            or kwargs["model_settings"].get("output_dtypes")
+            or {name: np.float for name in self.output_tensor_mapping}
+        )
         # sanity checks
-        assert output_tensor_mapping.keys() == self.output_dtypes.keys()
-        assert output_tensor_mapping.keys() == self.output_shapes.keys()
+        assert self.output_tensor_mapping.keys() == self.output_dtypes.keys()
+        assert self.output_tensor_mapping.keys() == self.output_shapes.keys()
 
         self.tf_model_name = (
-            kwargs.pop("model_settings", {}).get("tf_model_name")
+            tf_model_name
+            or kwargs.get("model_settings", {}).get("tf_model_name")
             or self.configuration_key
         )
-        # the GRPC stub
-        self.grpc_stub = None
-
-        super().__init__(**kwargs)
 
         connect_tf_serving(
             self.tf_model_name,
@@ -310,6 +335,24 @@ TF_SERVING_RETRY_POLICY = {
 
 
 @retry(**TF_SERVING_RETRY_POLICY)
+def connect_tf_serving_grpc(
+    model_name, host, port
+) -> prediction_service_pb2_grpc.PredictionServiceStub:
+    channel = grpc.insecure_channel(
+        f"{host}:{port}", [("grpc.lb_policy_name", "round_robin")]
+    )
+    stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
+    r = GetModelMetadataRequest()
+    r.model_spec.name = model_name
+    r.metadata_field.append("signature_def")
+    answ = stub.GetModelMetadata(r, 1)
+    version = answ.model_spec.version.value
+    if version != 1:
+        raise TFServingError(f"Bad model version: {version}!=1")
+    return stub
+
+
+@retry(**TF_SERVING_RETRY_POLICY)
 def connect_tf_serving(model_name, host, port, mode):
     logger.info(
         "Connecting to tensorflow serving",
@@ -319,18 +362,7 @@ def connect_tf_serving(model_name, host, port, mode):
         mode=mode,
     )
     if mode == "grpc":
-        channel = grpc.insecure_channel(
-            f"{host}:{port}", [("grpc.lb_policy_name", "round_robin")]
-        )
-        stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
-        r = GetModelMetadataRequest()
-        r.model_spec.name = model_name
-        r.metadata_field.append("signature_def")
-        answ = stub.GetModelMetadata(r, 1)
-        version = answ.model_spec.version.value
-        if version != 1:
-            raise TFServingError(f"Bad model version: {version}!=1")
-        return stub
+        return connect_tf_serving_grpc(model_name, host, port)
     elif mode in {"rest", "rest"}:
         response = requests.get(f"http://{host}:{port}/v1/models/{model_name}")
         if response.status_code != 200:

--- a/modelkit/core/types.py
+++ b/modelkit/core/types.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generic, List, Optional, TypeVar
+from types import ModuleType
+from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 import pydantic
 import pydantic.generics
@@ -9,6 +10,11 @@ ReturnType = TypeVar("ReturnType")
 
 TestReturnType = TypeVar("TestReturnType")
 TestItemType = TypeVar("TestItemType")
+
+# This type should be recursive:
+# Union[ModuleType, Type, List, str, "LibraryModelsType"]
+# but this is not currently supported
+LibraryModelsType = Union[ModuleType, Type, List, str]
 
 
 class TestCases(pydantic.generics.GenericModel, Generic[TestItemType, TestReturnType]):

--- a/modelkit/utils/tensorflow.py
+++ b/modelkit/utils/tensorflow.py
@@ -25,11 +25,11 @@ def write_config(destination, models, verbose=False):
             print(f.read())
 
 
-def deploy_tf_models(svc, mode, config_name="config", verbose=False):
+def deploy_tf_models(lib, mode, config_name="config", verbose=False):
     manager = AssetsManager()
-    configuration = svc.configuration
+    configuration = lib.configuration
     model_paths = {}
-    for model_name in svc.required_models:
+    for model_name in lib.required_models:
         model_configuration = configuration[model_name]
         if not issubclass(model_configuration.model_type, TensorflowModel):
             logger.info(f"Skipping non TF model `{model_name}`")
@@ -58,7 +58,7 @@ def deploy_tf_models(svc, mode, config_name="config", verbose=False):
     if mode == "local-docker" or mode == "local-process":
         logger.info("Checking that local models are present.")
         download_assets(
-            configuration=configuration, required_models=svc.required_models
+            configuration=configuration, required_models=lib.required_models
         )
         target = os.path.join(manager.assets_dir, f"{config_name}.config")
 

--- a/tests/test_auto_testing.py
+++ b/tests/test_auto_testing.py
@@ -60,23 +60,23 @@ def test_list_cases():
     ]
 
 
-# This function creates the test_auto_prediction_service test
-# but also a fixture called testing_prediction_service with a
+# This function creates the test_auto_model_library test
+# but also a fixture called testing_model_library with a
 # ModelLibrary
-# pytest will run the test_auto_prediction_service test
+# pytest will run the test_auto_model_library test
 modellibrary_fixture(
     models=TestableModel,
-    fixture_name="testing_prediction_service",
+    fixture_name="testing_model_library",
 )
 
 modellibrary_auto_test(
     models=TestableModel,
-    fixture_name="testing_prediction_service",
-    test_name="test_auto_prediction_service",
+    fixture_name="testing_model_library",
+    test_name="test_auto_model_library",
 )
 
 
 # The fixture with the ModelLibrary can be used elsewhere as usual
-def test_testing_prediction_service(testing_prediction_service):
-    m = testing_prediction_service.get("some_model")
+def test_testing_model_library(testing_model_library):
+    m = testing_model_library.get("some_model")
     assert m({"x": 1}).x == 1

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -44,7 +44,7 @@ def test_native_cache(cache_implementation):
         def _predict_batch(self, items):
             return items
 
-    svc = ModelLibrary(
+    lib = ModelLibrary(
         models=[SomeModel, SomeModelMultiple, SomeModelValidated],
         settings={
             "cache": {
@@ -55,17 +55,17 @@ def test_native_cache(cache_implementation):
         },
     )
 
-    assert isinstance(svc.cache, NativeCache)
+    assert isinstance(lib.cache, NativeCache)
 
-    m = svc.get("model")
-    m_multi = svc.get("model_multiple")
+    m = lib.get("model")
+    m_multi = lib.get("model_multiple")
 
     ITEMS = [{"ok": {"boomer": 1}}, {"ok": {"boomer": [2, 2, 3]}}]
 
     _do_model_test(m, ITEMS)
     _do_model_test(m_multi, ITEMS)
 
-    m_validated = svc.get("model_validated")
+    m_validated = lib.get("model_validated")
     _do_model_test(m_validated, ITEMS)
 
 
@@ -139,22 +139,22 @@ def test_redis_cache(redis_service):
         def _predict_batch(self, items):
             return items
 
-    svc = ModelLibrary(
+    lib = ModelLibrary(
         models=[SomeModel, SomeModelMultiple, SomeModelValidated],
         settings={"cache": {"cache_provider": "redis"}},
     )
 
-    assert isinstance(svc.cache, RedisCache)
+    assert isinstance(lib.cache, RedisCache)
 
-    m = svc.get("model")
-    m_multi = svc.get("model_multiple")
+    m = lib.get("model")
+    m_multi = lib.get("model_multiple")
 
     ITEMS = [{"ok": {"boomer": 1}}, {"ok": {"boomer": [2, 2, 3]}}]
 
     _do_model_test(m, ITEMS)
     _do_model_test(m_multi, ITEMS)
 
-    m_validated = svc.get("model_validated")
+    m_validated = lib.get("model_validated")
     _do_model_test(m_validated, ITEMS)
 
 
@@ -204,21 +204,21 @@ async def test_redis_cache_async(redis_service, event_loop):
             await asyncio.sleep(0)
             return items
 
-    svc = ModelLibrary(
+    lib = ModelLibrary(
         models=[SomeModel, SomeModelMultiple, SomeModelValidated],
         settings={"cache": {"cache_provider": "redis"}},
     )
 
-    assert isinstance(svc.cache, RedisCache)
+    assert isinstance(lib.cache, RedisCache)
 
-    m = svc.get("model")
-    m_multi = svc.get("model_multiple")
+    m = lib.get("model")
+    m_multi = lib.get("model_multiple")
 
     ITEMS = [{"ok": {"boomer": 1}}, {"ok": {"boomer": [2, 2, 3]}}]
 
     await _do_model_test_async(m, ITEMS)
     await _do_model_test_async(m_multi, ITEMS)
-    await svc.aclose()
+    await lib.aclose()
 
-    m_validated = svc.get("model_validated")
+    m_validated = lib.get("model_validated")
     await _do_model_test_async(m_validated, ITEMS)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -263,7 +263,7 @@ def test_download_assets_version(assetsmanager_settings):
         models=[SomeModel],
     )
     assert model_assets["model0"] == {"category/asset:0.0"}
-    assert assets_info["category/asset:0.0"]["version"] == "0.0"
+    assert assets_info["category/asset:0.0"].version == "0.0"
 
     class SomeModel(Asset):
         CONFIGURATIONS = {"model0": {"asset": "category/asset"}}
@@ -273,7 +273,7 @@ def test_download_assets_version(assetsmanager_settings):
         models=[SomeModel],
     )
     assert model_assets["model0"] == {"category/asset"}
-    assert assets_info["category/asset"]["version"] == "1.0"
+    assert assets_info["category/asset"].version == "1.0"
 
     class SomeModel(Asset):
         CONFIGURATIONS = {"model0": {"asset": "category/asset:0"}}
@@ -283,7 +283,7 @@ def test_download_assets_version(assetsmanager_settings):
         models=[SomeModel],
     )
     assert model_assets["model0"] == {"category/asset:0"}
-    assert assets_info["category/asset:0"]["version"] == "0.1"
+    assert assets_info["category/asset:0"].version == "0.1"
 
 
 def test_download_assets_dependencies(assetsmanager_settings):
@@ -302,8 +302,8 @@ def test_download_assets_dependencies(assetsmanager_settings):
 
     assert model_assets["model0"] == {"category/asset"}
     assert model_assets["model1"] == {"category/asset:0", "category/asset"}
-    assert assets_info["category/asset"]["version"] == "1.0"
-    assert assets_info["category/asset:0"]["version"] == "0.1"
+    assert assets_info["category/asset"].version == "1.0"
+    assert assets_info["category/asset:0"].version == "0.1"
 
 
 def test_write_tf_serving_config(base_dir, assetsmanager_settings):

--- a/tests/test_distant_http_model.py
+++ b/tests/test_distant_http_model.py
@@ -61,16 +61,16 @@ async def test_distant_http_model(run_mocked_service, event_loop):
             }
         }
 
-    svc = ModelLibrary(models=[SomeDistantHTTPModel, SomeAsyncDistantHTTPModel])
+    lib = ModelLibrary(models=[SomeDistantHTTPModel, SomeAsyncDistantHTTPModel])
     ITEM = {"some_content": "something"}
 
     # Test with asynchronous mode
-    m = svc.get("some_model_async")
+    m = lib.get("some_model_async")
     with pytest.raises(AssertionError):
         assert ITEM == m(ITEM)
     await _check_service_async(m, ITEM)
-    await svc.aclose()
+    await lib.aclose()
 
     # Test with synchronous mode
-    m = svc.get("some_model_sync")
+    m = lib.get("some_model_sync")
     assert ITEM == m(ITEM)

--- a/tests/test_tf_model.py
+++ b/tests/test_tf_model.py
@@ -49,9 +49,11 @@ TEST_ITEMS = [
 def test_tf_model_local_path():
     model = DummyTFModel(
         asset_path=os.path.join(TEST_DIR, "testdata", "dummy_tf_model", "0.0"),
-        output_dtypes={"lambda": np.float32},
-        output_tensor_mapping={"lambda": "nothing"},
-        output_shapes={"lambda": (3, 2, 1)},
+        model_settings={
+            "output_dtypes": {"lambda": np.float32},
+            "output_tensor_mapping": {"lambda": "nothing"},
+            "output_shapes": {"lambda": (3, 2, 1)},
+        },
     )
     v = np.zeros((3, 2, 1), dtype=np.float32)
     assert np.allclose(v, model({"input_1": v})["lambda"])

--- a/tests/test_tf_model.py
+++ b/tests/test_tf_model.py
@@ -128,8 +128,8 @@ async def test_iso_serving_mode(tf_serving, event_loop):
 
     _compare_models(model_rest, model_grpc, TEST_ITEMS)
 
-    await lib_serving_rest.close_connections()
-    await lib_serving_grpc.close_connections()
+    await lib_serving_rest.aclose()
+    await lib_serving_grpc.aclose()
 
 
 def compare_result(x, y, tolerance):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -129,12 +129,15 @@ def test_validate_return_spec(service_settings):
         def _predict(self, item):
             return item
 
-    m = SomeValidatedModel(service_settings)
+    m = SomeValidatedModel(service_settings=service_settings)
     ret = m({"x": 10})
     assert ret.x == 10
 
-    with pytest.raises(ReturnValueValidationException):
-        m({"x": "something", "blabli": 10})
+    if m.service_settings.enable_validation:
+        with pytest.raises(ReturnValueValidationException):
+            m({"x": "something", "blabli": 10})
+    else:
+        m.predict({"x": "something", "blabli": 10})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR contains a variety of minor improvements and cleanups to modelkit's internals:
- I add a lot of type annotations to `model` and `library` object attributes and methods
- remove `**kwargs` Model initialization in favor of explicit attributes, fix some `super().__init__` calls that mistakenly had `self`
- fix a problem with the validation test
- rename variables that still refered to prediction services 
- rename modelkit's `BaseModel` to `AbstractModel` to avoid the mental clash with pydantic's BaseModel