### PR TITLE
Fix testing no tf

### DIFF
--- a/modelkit/cli.py
+++ b/modelkit/cli.py
@@ -20,7 +20,7 @@ from modelkit import ModelLibrary
 from modelkit.api import ModelkitAutoAPIRouter
 from modelkit.assets.cli import assets_cli
 from modelkit.core.model_configuration import configure, list_assets
-from modelkit.core.models.tensorflow_model import safe_np_dump
+from modelkit.utils.serialization import safe_np_dump
 from modelkit.utils.tensorflow import deploy_tf_models
 
 

--- a/modelkit/core/models/tensorflow_model.py
+++ b/modelkit/core/models/tensorflow_model.py
@@ -15,6 +15,7 @@ from tenacity import (
 
 from modelkit.core.model import AsyncModel, Model
 from modelkit.core.types import ItemType, ReturnType
+from modelkit.utils.serialization import safe_np_dump
 
 logger = get_logger(__name__)
 
@@ -35,16 +36,6 @@ try:
 
 except ModuleNotFoundError:
     logger.info("Tensorflow serving is not installed")
-
-
-def safe_np_dump(obj):
-    if isinstance(obj, np.integer):
-        return int(obj)
-    elif isinstance(obj, np.floating):
-        return float(obj)
-    elif isinstance(obj, np.ndarray):
-        return obj.tolist()
-    return obj.item()
 
 
 class TensorflowModel(Model[ItemType, ReturnType]):

--- a/modelkit/testing/__init__.py
+++ b/modelkit/testing/__init__.py
@@ -2,8 +2,16 @@ from modelkit.testing.fixtures import (
     JSONTestResult,
     modellibrary_auto_test,
     modellibrary_fixture,
-    tf_serving_fixture,
 )
 from modelkit.testing.reference import ReferenceJson, ReferenceText
+
+try:
+    from modelkit.testing.tf_serving import tf_serving_fixture
+except NameError:
+    # This occurs because type annotations in
+    # modelkit.core.models.tensorflow_model will raise
+    # `NameError: name 'prediction_service_pb2_grpc' is not defined`
+    # when tensorflow-serving-api is not installed
+    pass
 
 # flake8: noqa: F401

--- a/modelkit/testing/fixtures.py
+++ b/modelkit/testing/fixtures.py
@@ -1,7 +1,6 @@
 import dataclasses
 import inspect
 import os
-import subprocess
 
 import numpy as np
 import pydantic
@@ -10,9 +9,7 @@ import pydantic.generics
 from modelkit.core.library import ModelLibrary
 from modelkit.core.model import Model
 from modelkit.core.model_configuration import configure
-from modelkit.core.models.tensorflow_model import TensorflowModel, connect_tf_serving
 from modelkit.testing.reference import ReferenceJson
-from modelkit.utils.tensorflow import deploy_tf_models
 
 
 @dataclasses.dataclass
@@ -102,68 +99,3 @@ def modellibrary_fixture(
     # to the caller's local variables under their desired names
     frame = inspect.currentframe().f_back
     frame.f_locals[fixture_name] = fixture_function
-
-
-def tf_serving_fixture(request, lib, deployment="docker"):
-    cmd = [
-        "--port=8500",
-        "--rest_api_port=8501",
-    ]
-
-    if deployment == "process":
-        deploy_tf_models(lib, "local-process", config_name="testing")
-        proc = subprocess.Popen(
-            [
-                "tensorflow_model_server",
-                "--model_config_file="
-                f"{os.environ['MODELKIT_ASSETS_DIR']}/testing.config",
-            ]
-            + cmd
-        )
-
-        def finalize():
-            proc.terminate()
-
-    else:
-        deploy_tf_models(lib, "local-docker", config_name="testing")
-        # kill previous tfserving container (if any)
-        subprocess.call(
-            ["docker", "rm", "-f", "modelkit-tfserving-tests"],
-            stderr=subprocess.DEVNULL,
-        )
-        # start tfserving as docker container
-        tfserving_proc = subprocess.Popen(
-            [
-                "docker",
-                "run",
-                "--name",
-                "modelkit-tfserving-tests",
-                "--volume",
-                f"{os.environ['MODELKIT_ASSETS_DIR']}:/config",
-                "-p",
-                "8500:8500",
-                "-p",
-                "8501:8501",
-                "tensorflow/serving:2.4.0",
-                "--model_config_file=/config/testing.config",
-            ]
-            + cmd
-        )
-
-        def finalize():
-            subprocess.call(["docker", "kill", "modelkit-tfserving-tests"])
-            tfserving_proc.terminate()
-
-    request.addfinalizer(finalize)
-    connect_tf_serving(
-        next(
-            (
-                x
-                for x in lib.required_models
-                if issubclass(lib.configuration[x].model_type, TensorflowModel)
-            )
-        ),
-        "localhost",
-        8500,
-        "grpc",
-    )

--- a/modelkit/testing/tf_serving.py
+++ b/modelkit/testing/tf_serving.py
@@ -1,0 +1,70 @@
+import os
+import subprocess
+
+from modelkit.core.models.tensorflow_model import TensorflowModel, connect_tf_serving
+from modelkit.utils.tensorflow import deploy_tf_models
+
+
+def tf_serving_fixture(request, lib, deployment="docker"):
+    cmd = [
+        "--port=8500",
+        "--rest_api_port=8501",
+    ]
+
+    if deployment == "process":
+        deploy_tf_models(lib, "local-process", config_name="testing")
+        proc = subprocess.Popen(
+            [
+                "tensorflow_model_server",
+                "--model_config_file="
+                f"{os.environ['MODELKIT_ASSETS_DIR']}/testing.config",
+            ]
+            + cmd
+        )
+
+        def finalize():
+            proc.terminate()
+
+    else:
+        deploy_tf_models(lib, "local-docker", config_name="testing")
+        # kill previous tfserving container (if any)
+        subprocess.call(
+            ["docker", "rm", "-f", "modelkit-tfserving-tests"],
+            stderr=subprocess.DEVNULL,
+        )
+        # start tfserving as docker container
+        tfserving_proc = subprocess.Popen(
+            [
+                "docker",
+                "run",
+                "--name",
+                "modelkit-tfserving-tests",
+                "--volume",
+                f"{os.environ['MODELKIT_ASSETS_DIR']}:/config",
+                "-p",
+                "8500:8500",
+                "-p",
+                "8501:8501",
+                "tensorflow/serving:2.4.0",
+                "--model_config_file=/config/testing.config",
+            ]
+            + cmd
+        )
+
+        def finalize():
+            subprocess.call(["docker", "kill", "modelkit-tfserving-tests"])
+            tfserving_proc.terminate()
+
+    request.addfinalizer(finalize)
+    connect_tf_serving(
+        next(
+            (
+                x
+                for x in lib.required_models
+                if issubclass(lib.configuration[x].model_type, TensorflowModel)
+            )
+        ),
+        "localhost",
+        8500,
+        "grpc",
+    )

--- a/modelkit/utils/serialization.py
+++ b/modelkit/utils/serialization.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+def safe_np_dump(obj):
+    if isinstance(obj, np.integer):
+        return int(obj)
+    elif isinstance(obj, np.floating):
+        return float(obj)
+    elif isinstance(obj, np.ndarray):
+        return obj.tolist()
+    return obj.item()

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ def test(session):
 @nox.session(python=["3.7"])
 def coverage(session):
     # Install deps and the package itself.
-    session.install("-r", "requirements-dev.txt")
+    session.install("-r", "requirements-optional.txt")
 
     session.run(
         "coverage",

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,5 @@
+-r "requirements-dev.txt"
+
+grpcio
+tensorflow
+tensorflow-serving-api

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -2,6 +2,7 @@
 
 if [[ $OS_NAME == "ubuntu-latest" ]]; then
     export ENABLE_TF_SERVING_TEST=True
+    export ENABLE_TF_TEST=True
     export ENABLE_REDIS_TEST=True
     export ENABLE_S3_TEST=True
     export ENABLE_GCS_TEST=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import tempfile
 
 import pytest
 
+from tests import TEST_DIR
+
 
 @pytest.fixture(scope="function")
 def base_dir():
@@ -17,6 +19,20 @@ def working_dir(base_dir):
     os.makedirs(working_dir)
 
     yield working_dir
+
+
+@pytest.fixture
+def assetsmanager_settings(working_dir):
+    yield {
+        "remote_store": {
+            "driver": {
+                "storage_provider": "local",
+                "bucket": os.path.join(TEST_DIR, "testdata", "test-bucket"),
+            },
+            "storage_prefix": "assets-prefix",
+        },
+        "assets_dir": working_dir,
+    }
 
 
 def clean_env():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,6 @@ import os
 
 import pytest
 
-from modelkit import testing
 from modelkit.core.library import (
     ConfigurationNotFoundException,
     ModelLibrary,
@@ -18,8 +17,6 @@ from modelkit.core.model_configuration import (
     list_assets,
 )
 from modelkit.core.settings import LibrarySettings
-from modelkit.utils.tensorflow import write_config
-from tests import TEST_DIR
 
 
 def test_override_asset():
@@ -240,20 +237,6 @@ def test_list_assets():
     )
 
 
-@pytest.fixture
-def assetsmanager_settings(working_dir):
-    yield {
-        "remote_store": {
-            "driver": {
-                "storage_provider": "local",
-                "bucket": os.path.join(TEST_DIR, "testdata", "test-bucket"),
-            },
-            "storage_prefix": "assets-prefix",
-        },
-        "assets_dir": working_dir,
-    }
-
-
 def test_download_assets_version(assetsmanager_settings):
     class SomeModel(Asset):
         CONFIGURATIONS = {"model0": {"asset": "category/asset:0.0"}}
@@ -304,13 +287,6 @@ def test_download_assets_dependencies(assetsmanager_settings):
     assert model_assets["model1"] == {"category/asset:0", "category/asset"}
     assert assets_info["category/asset"].version == "1.0"
     assert assets_info["category/asset:0"].version == "0.1"
-
-
-def test_write_tf_serving_config(base_dir, assetsmanager_settings):
-    write_config(os.path.join(base_dir, "test.config"), {"model0": "/some/path"})
-    ref = testing.ReferenceText(os.path.join(TEST_DIR, "testdata"))
-    with open(os.path.join(base_dir, "test.config")) as f:
-        ref.assert_equal("test.config", f.read())
 
 
 def test_load_model():

--- a/tests/test_module_configure.py
+++ b/tests/test_module_configure.py
@@ -3,14 +3,17 @@ import sys
 
 from modelkit.core.model_configuration import configure
 from tests import TEST_DIR
+from tests.conftest import skip_unless
 
 
+@skip_unless("ENABLE_TF_TEST", "True")
 def test_configure_package():
     sys.path.append(os.path.join(TEST_DIR, "testdata"))
     confs = configure(models="test_module")
     assert len(confs) == 5
 
 
+@skip_unless("ENABLE_TF_TEST", "True")
 def test_configure_module():
     sys.path.append(os.path.join(TEST_DIR, "testdata"))
     confs = configure(models="test_module.module_a")


### PR DESCRIPTION
When `tensorflow-serving-api` is not installed, some of the objects in `modelkit` are not available (obviously). 

Here there was a "leak" of sorts that made both the CLI and the `modelkit.testing` submodule unusable in this case. This is because of type annotations which raised a `NameError`. 

In this PR I make sure that this no longer occurs, by catching NameErrors appropriately. I also isolate tests that necessitate the optional installs `tensorflow` and  `tensorflow-serving-api`, and run tests without TF installed at all on OSX and Windows on the CI. 



