### PR TITLE
Add tests configurations

### DIFF
--- a/docs/library/testing.md
+++ b/docs/library/testing.md
@@ -25,11 +25,21 @@ In addition, it creates a test called `test_auto_model_library` that iterates th
 
 ### Defining test cases
 
-Any `modelkit.core.Model` can define its own test cases which are discoverable by the test created by `make_modellibrary_test`:
+Any `modelkit.core.Model` can define its own test cases which are discoverable by the test created by `make_modellibrary_test`.
+
+There are two ways of defining test cases.
+
+#### Adding TEST_CASES as a class attribute
+
+Tests added to the TEST_CASES class attribute are shared across the different models defined in the CONFIGURATIONS map.
+
+In the following example, 4 test cases will be ran:
+- 2 for `some_model_a`
+- 2 for `some_model_b`
 
 ```python
 class TestableModel(Model[ModelItemType, ModelItemType]):
-    CONFIGURATIONS: Dict[str, Dict] = {"some_model": {}}
+    CONFIGURATIONS: Dict[str, Dict] = {"some_model_a": {}, "some_model_b": {}}
 
     TEST_CASES = {
         "cases": [
@@ -42,6 +52,32 @@ class TestableModel(Model[ModelItemType, ModelItemType]):
         return item
 
 ```
+
+#### Adding test_cases to the CONFIGURATIONS map
+
+Tests added to the CONFIGURATIONS map are restricted to their parent.
+
+In the following example, 2 test cases will be ran for `some_model_a`:
+
+```python
+class TestableModel(Model[ModelItemType, ModelItemType]):
+    CONFIGURATIONS: Dict[str, Dict] = {
+        "some_model_a": { 
+            "test_cases": {
+                "cases": [
+                    {"item": {"x": 1}, "result": {"x": 1}},
+                    {"item": {"x": 2}, "result": {"x": 2}},
+                ],
+            }
+        },
+        "some_model_b": {},
+    }
+
+    def _predict(self, item):
+        return item
+
+```
+Both ways of testing can be used simultaneously and interchangeably.
 
 Each test is instantiated with an item value and a result value, the automatic test will iterate through them and run the equivalent of:
 

--- a/docs/library/testing.md
+++ b/docs/library/testing.md
@@ -41,12 +41,10 @@ In the following example, 4 test cases will be ran:
 class TestableModel(Model[ModelItemType, ModelItemType]):
     CONFIGURATIONS: Dict[str, Dict] = {"some_model_a": {}, "some_model_b": {}}
 
-    TEST_CASES = {
-        "cases": [
+    TEST_CASES = [
             {"item": {"x": 1}, "result": {"x": 1}},
             {"item": {"x": 2}, "result": {"x": 2}},
         ]
-    }
 
     def _predict(self, item):
         return item

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -366,13 +366,6 @@ class ModelLibrary:
             if isinstance(model, AsyncModel):
                 await model.close()
 
-    def _iterate_test_cases(self):
-        model_types = {type(model_type) for model_type in self._models.values()}
-        for model_type in model_types:
-            for model_key, item, result in model_type._iterate_test_cases():
-                if model_key in self.models:
-                    yield self.get(model_key), item, result
-
     def describe(self, console=None) -> None:
         if not console:
             console = Console()

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -23,7 +23,12 @@ from rich.tree import Tree
 from structlog import get_logger
 
 from modelkit.core.settings import LibrarySettings
-from modelkit.core.types import ItemType, ModelTestingConfiguration, ReturnType
+from modelkit.core.types import (
+    ItemType,
+    ModelTestingConfiguration,
+    ReturnType,
+    TestCases,
+)
 from modelkit.utils import traceback
 from modelkit.utils.cache import Cache, CacheItem
 from modelkit.utils.memory import PerformanceTracker
@@ -256,20 +261,40 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
         self.initialize_validation_models()
 
     @classmethod
-    def _iterate_test_cases(cls, model_keys=None):
-        if not hasattr(cls, "TEST_CASES"):
-            logger.debug("No TEST_CASES defined", model_type=cls.__name__)
+    def _iterate_test_cases(cls, model_key: Optional[str] = None):
+        if (
+            not hasattr(cls, "TEST_CASES")
+            and not (
+                model_key
+                or any("test_cases" in conf for conf in cls.CONFIGURATIONS.values())
+            )
+            and (model_key and "test_cases" not in cls.CONFIGURATIONS[model_key])
+        ) or (model_key and model_key not in cls.CONFIGURATIONS):
+            logger.debug("No test cases defined", model_type=cls.__name__)
             return
-        if isinstance(cls.TEST_CASES, dict):
-            # This used to be OK with type instantiation but fails with a pydantic
-            # error since 1.18
-            # test_cases = ModelTestingConfiguration[ItemType, ReturnType]
-            test_cases = ModelTestingConfiguration(**cls.TEST_CASES)
-        else:
-            test_cases = cls.TEST_CASES
-        model_keys = model_keys or test_cases.model_keys or cls.CONFIGURATIONS.keys()
+
+        model_keys = [model_key] if model_key else cls.CONFIGURATIONS.keys()
+        cls_test_cases: List[TestCases] = []
+
+        if hasattr(cls, "TEST_CASES"):
+            if isinstance(cls.TEST_CASES, dict):
+                # This used to be OK with type instantiation but fails with a pydantic
+                # error since 1.18
+                # test_cases = ModelTestingConfiguration[ItemType, ReturnType]
+                cls_test_cases = ModelTestingConfiguration(**cls.TEST_CASES).cases
+            else:
+                cls_test_cases = cls.TEST_CASES.cases
+
         for model_key in model_keys:
-            for case in test_cases.cases:
+            for case in cls_test_cases:
+                yield model_key, case.item, case.result, case.keyword_args
+
+            conf = cls.CONFIGURATIONS[model_key]
+            if "test_cases" not in conf:
+                continue
+            for case in conf["test_cases"]["cases"]:
+                if isinstance(case, dict):
+                    case = TestCases(**case)
                 yield model_key, case.item, case.result, case.keyword_args
 
     def describe(self, t=None):
@@ -350,7 +375,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
     def test(self):
         console = Console()
         for i, (model_key, item, expected, keyword_args) in enumerate(
-            self._iterate_test_cases(model_keys=[self.configuration_key])
+            self._iterate_test_cases(model_key=self.configuration_key)
         ):
             result = None
             try:

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -23,7 +23,7 @@ from rich.tree import Tree
 from structlog import get_logger
 
 from modelkit.core.settings import LibrarySettings
-from modelkit.core.types import ItemType, ReturnType, TestCases
+from modelkit.core.types import ItemType, ReturnType, TestCase
 from modelkit.utils import traceback
 from modelkit.utils.cache import Cache, CacheItem
 from modelkit.utils.memory import PerformanceTracker
@@ -269,7 +269,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
             return
 
         model_keys = [model_key] if model_key else cls.CONFIGURATIONS.keys()
-        cls_test_cases: List[TestCases] = []
+        cls_test_cases: List[TestCase] = []
 
         if hasattr(cls, "TEST_CASES"):
             cls_test_cases = cls.TEST_CASES
@@ -277,7 +277,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
         for model_key in model_keys:
             for case in cls_test_cases:
                 if isinstance(case, dict):
-                    case = TestCases(**case)
+                    case = TestCase(**case)
                 yield model_key, case.item, case.result, case.keyword_args
 
             conf = cls.CONFIGURATIONS[model_key]
@@ -285,7 +285,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
                 continue
             for case in conf["test_cases"]:
                 if isinstance(case, dict):
-                    case = TestCases(**case)
+                    case = TestCase(**case)
                 yield model_key, case.item, case.result, case.keyword_args
 
     def describe(self, t=None):

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -187,9 +187,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
     that either take items or lists of items.
     """
 
-    # The correct type below raises an error with pydantic after version 0.18
-    # TEST_CASES: Union[ModelTestingConfiguration[ItemType, ReturnType], Dict]
-    TEST_CASES: Any
+    TEST_CASES: List[Union[TestCase[ItemType, ReturnType], Dict]]
 
     def __init__(
         self,
@@ -269,7 +267,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
             return
 
         model_keys = [model_key] if model_key else cls.CONFIGURATIONS.keys()
-        cls_test_cases: List[TestCase] = []
+        cls_test_cases: List[Union[TestCase[ItemType, ReturnType], Dict]] = []
 
         if hasattr(cls, "TEST_CASES"):
             cls_test_cases = cls.TEST_CASES

--- a/modelkit/core/types.py
+++ b/modelkit/core/types.py
@@ -17,7 +17,7 @@ TestItemType = TypeVar("TestItemType")
 LibraryModelsType = Union[ModuleType, Type, List, str]
 
 
-class TestCases(pydantic.generics.GenericModel, Generic[TestItemType, TestReturnType]):
+class TestCase(pydantic.generics.GenericModel, Generic[TestItemType, TestReturnType]):
     item: TestItemType
     result: TestReturnType
     keyword_args: Dict[str, Any] = {}

--- a/modelkit/core/types.py
+++ b/modelkit/core/types.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Type, TypeVar, Union
 
 import pydantic
 import pydantic.generics
@@ -21,10 +21,3 @@ class TestCases(pydantic.generics.GenericModel, Generic[TestItemType, TestReturn
     item: TestItemType
     result: TestReturnType
     keyword_args: Dict[str, Any] = {}
-
-
-class ModelTestingConfiguration(
-    pydantic.generics.GenericModel, Generic[TestItemType, TestReturnType]
-):
-    model_keys: Optional[List[str]]
-    cases: List[TestCases[TestItemType, TestReturnType]]

--- a/tests/test_auto_testing.py
+++ b/tests/test_auto_testing.py
@@ -3,7 +3,6 @@ from typing import Dict
 import pydantic
 
 from modelkit.core.model import Model
-from modelkit.core.types import ModelTestingConfiguration
 from modelkit.testing import modellibrary_auto_test, modellibrary_fixture
 
 
@@ -18,13 +17,11 @@ class ModelReturnType(pydantic.BaseModel):
 class TestableModel(Model[ModelItemType, ModelItemType]):
     CONFIGURATIONS: Dict[str, Dict] = {"some_model": {}}
 
-    TEST_CASES = {
-        "cases": [
-            {"item": {"x": 1}, "result": {"x": 1}},
-            {"item": {"x": 2}, "result": {"x": 2}},
-            {"item": {"x": 1}, "result": {"x": 2}, "keyword_args": {"add_one": True}},
-        ]
-    }
+    TEST_CASES = [
+        {"item": {"x": 1}, "result": {"x": 1}},
+        {"item": {"x": 2}, "result": {"x": 2}},
+        {"item": {"x": 1}, "result": {"x": 2}, "keyword_args": {"add_one": True}},
+    ]
 
     def _predict(self, item, add_one=False):
         if add_one:
@@ -38,9 +35,7 @@ def test_list_cases():
     class SomeModel(Model[ModelItemType, ModelItemType]):
         CONFIGURATIONS = {"some_model": {}}
 
-        TEST_CASES = ModelTestingConfiguration(
-            cases=[{"item": {"x": 1}, "result": {"x": 1}}]
-        )
+        TEST_CASES = [{"item": {"x": 1}, "result": {"x": 1}}]
 
         def _predict(self, item):
             return item
@@ -52,7 +47,7 @@ def test_list_cases():
     class TestableModel(Model[ModelItemType, ModelItemType]):
         CONFIGURATIONS = {"some_model": {}}
 
-        TEST_CASES = {"cases": [{"item": {"x": 1}, "result": {"x": 1}}]}
+        TEST_CASES = [{"item": {"x": 1}, "result": {"x": 1}}]
 
         def _predict(self, item):
             return item
@@ -63,12 +58,10 @@ def test_list_cases():
 
     class TestableModel(Model[ModelItemType, ModelItemType]):
         CONFIGURATIONS = {
-            "some_model": {
-                "test_cases": {"cases": [{"item": {"x": 1}, "result": {"x": 1}}]}
-            },
+            "some_model": {"test_cases": [{"item": {"x": 1}, "result": {"x": 1}}]},
             "some_other_model": {},
         }
-        TEST_CASES = {"cases": [{"item": {"x": 1}, "result": {"x": 1}}]}
+        TEST_CASES = [{"item": {"x": 1}, "result": {"x": 1}}]
 
         def _predict(self, item):
             return item

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -427,14 +427,12 @@ def test_override_prefix(assetsmanager_settings):
     assert prediction.endswith(os.path.join("category", "override-asset", "1.0"))
 
 
-SYNC_ASYNC_TEST_CASES = {
-    "cases": [
-        {"item": "", "result": 0},
-        {"item": "a", "result": 1},
-        {"item": ["a", "b", "c"], "result": 3},
-        {"item": range(100), "result": 100},
-    ]
-}
+SYNC_ASYNC_TEST_CASES = [
+    {"item": "", "result": 0},
+    {"item": "a", "result": 1},
+    {"item": ["a", "b", "c"], "result": 3},
+    {"item": range(100), "result": 100},
+]
 
 
 def test_model_sync_test():


### PR DESCRIPTION
This PR aims at introducing `test_cases` in the CONFIGURATIONS map defined at class level, so that to be able to write tests restricted to a given model.

Moreover, TEST_CASES is now the way to go if you want to define *upper-level class tests*, which will be ran for every model configuration.

E.g.:

```python
class TestableModel(Model[ModelItemType, ModelItemType]):
    CONFIGURATIONS: Dict[str, Dict] = {
        "some_model_a": { 
            "test_cases": {
                "cases": [
                    {"item": {"x": 1}, "result": {"x": 1}},
                    {"item": {"x": 2}, "result": {"x": 2}},
                ],
            }
        },
        "some_model_b": {},
    }
    def _predict(self, item):
        return item
```

Thanks for reviewing