### PR TITLE
storage: log when no remote storage provider is available

### DIFF
--- a/modelkit/assets/manager.py
+++ b/modelkit/assets/manager.py
@@ -28,6 +28,9 @@ class AssetsManager:
         self.remote_assets_store = None
         if settings.remote_store:
             self.remote_assets_store = RemoteAssetsStore(**settings.remote_store.dict())
+            logger.debug("AssetsManager created with remote storage provider")
+        else:
+            logger.debug("AssetsManager created without a remote storage provider")
 
     def get_local_versions_info(self, name):
         if os.path.isdir(name):

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -32,7 +32,7 @@ class DriverSettings(BaseSettings):
             return {"storage_provider": None, "settings": None}
         if storage_provider not in SUPPORTED_MODELKIT_STORAGE_PROVIDERS:
             logger.error(
-                f"Unkown storage provider `{storage_provider}`, "
+                f"Unknown storage provider `{storage_provider}`, "
                 "no remote storage will be available"
             )
             raise ValueError

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 import pydantic
 from pydantic import BaseModel, BaseSettings, ValidationError, root_validator, validator
+from structlog import get_logger
 
 from modelkit.assets.drivers.gcs import GCSDriverSettings
 from modelkit.assets.drivers.local import LocalDriverSettings
@@ -11,6 +12,8 @@ from modelkit.assets.drivers.s3 import S3DriverSettings
 from modelkit.assets.errors import InvalidAssetSpecError
 
 SUPPORTED_MODELKIT_STORAGE_PROVIDERS = {"s3", "gcs", "local"}
+
+logger = get_logger(__name__)
 
 
 class DriverSettings(BaseSettings):
@@ -28,7 +31,11 @@ class DriverSettings(BaseSettings):
         if not storage_provider:
             return {"storage_provider": None, "settings": None}
         if storage_provider not in SUPPORTED_MODELKIT_STORAGE_PROVIDERS:
-            raise ValueError(f"Unkown storage provider `{storage_provider}`.")
+            logger.error(
+                f"Unkown storage provider `{storage_provider}`, "
+                "no remote storage will be available"
+            )
+            raise ValueError
         if storage_provider == "gcs":
             settings = GCSDriverSettings(**fields)
         if storage_provider == "s3":


### PR DESCRIPTION
Currently, when the `MODELKIT_STORAGE_PROVIDER` is unset, or simply has a wrong value, nothing is logged, but the `AssetsManager` will still function from the local dir. 

This can get confusing. Here I log with `error` when it is set but not valid, and with `debug` to provide the information of whether the manager has remote storage or not.