### PR TITLE
Raise an error when neither `_predict` nor `_predict_batch` is overriden

### DIFF
--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -387,7 +387,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
                 raise BothPredictsOverridenError()
             self._predict_mode = PredictMode.BATCH
         if not self._predict_mode:
-            raise NoPredictOverridenError
+            raise NoPredictOverridenError("_predict or _predict_batch must be overriden")
 
 
 class CallableWithAttribute(Protocol):

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -384,7 +384,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
             self._predict_mode = PredictMode.SINGLE
         if not hasattr(self._predict_batch, "__not_overriden__"):
             if self._predict_mode == PredictMode.SINGLE:
-                raise BothPredictsOverridenError()
+                raise BothPredictsOverridenError("_predict OR _predict_batch must be overriden, not both")
             self._predict_mode = PredictMode.BATCH
         if not self._predict_mode:
             raise NoPredictOverridenError("_predict or _predict_batch must be overriden")

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -390,17 +390,17 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
             raise NoPredictOverridenError
 
 
-class ActionWithAttributes(Protocol):
+class CallableWithAttribute(Protocol):
     __call__: Callable
     __not_overriden__: Optional[bool]
 
 
-def not_overriden(func: Callable) -> ActionWithAttributes:
+def not_overriden(func: Callable) -> CallableWithAttribute:
     # Decorating with an attribute while preserving
     # typing is slightly tricky
     # https://github.com/python/mypy/issues/2087
 
-    func_with_attributes = cast(ActionWithAttributes, func)
+    func_with_attributes = cast(CallableWithAttribute, func)
     func_with_attributes.__not_overriden__ = True
     return func_with_attributes
 

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -25,8 +25,11 @@ def _double(x):
     ],
 )
 def test_identitybatch_batch_process(func, items, batch_size, expected, monkeypatch):
+    class SomeModel(Model):
+        def _predict(self, item):
+            return item
 
-    m = Model()
+    m = SomeModel()
     monkeypatch.setattr(m, "_predict_batch", func)
     if batch_size:
         assert m.predict_batch(items, batch_size=batch_size) == expected
@@ -64,7 +67,11 @@ def test_callback_batch_process(
             assert items[batch_step : batch_step + batch_size] == batch_items
         steps += 1
 
-    m = Model()
+    class SomeModel(Model):
+        def _predict(self, item):
+            return item
+
+    m = SomeModel()
     monkeypatch.setattr(m, "_predict_batch", func)
     m.predict_batch(items, batch_size=batch_size, _callback=_callback)
     assert steps == expected_steps

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -177,6 +177,9 @@ def test_modellibrary_required_models():
     class SomeModel(Model):
         CONFIGURATIONS = {"yolo": {}, "les simpsons": {}}
 
+        def _predict(self, item):
+            return item
+
     p = ModelLibrary(models=SomeModel)
     m = p.get("yolo")
     assert m
@@ -304,8 +307,14 @@ def test_required_models():
     class SomeModel(Model):
         CONFIGURATIONS = {"model": {}}
 
+        def _predict(self, item):
+            return item
+
     class SomeOtherModel(Model):
         CONFIGURATIONS = {"other_model": {}}
+
+        def _predict(self, item):
+            return item
 
     lib = ModelLibrary(required_models=[], models=[SomeModel, SomeOtherModel])
     assert len(lib.models) == 0

--- a/tests/test_predict_override.py
+++ b/tests/test_predict_override.py
@@ -1,0 +1,75 @@
+import pytest
+
+from modelkit.core.model import (
+    AsyncModel,
+    BothPredictsOverridenError,
+    Model,
+    NoPredictOverridenError,
+    PredictMode,
+)
+
+
+def test_predict_override():
+    class NoPredictModel(Model):
+        pass
+
+    with pytest.raises(NoPredictOverridenError):
+        NoPredictModel()
+
+    class BatchPredictModel(Model):
+        def _predict_batch(self, items):
+            return items
+
+    m = BatchPredictModel()
+    assert m._predict_mode == PredictMode.BATCH
+
+    class SinglePredictModel(Model):
+        def _predict(self, item):
+            return item
+
+    m = SinglePredictModel()
+    assert m._predict_mode == PredictMode.SINGLE
+
+    class BothPredictModel(Model):
+        def _predict(self, item):
+            return item
+
+        def _predict_batch(self, items):
+            return items
+
+    m = SinglePredictModel()
+    with pytest.raises(BothPredictsOverridenError):
+        BothPredictModel()
+
+
+def test_predict_override_async():
+    class NoPredictModel(AsyncModel):
+        pass
+
+    with pytest.raises(NoPredictOverridenError):
+        NoPredictModel()
+
+    class BatchPredictModel(AsyncModel):
+        async def _predict_batch(self, items):
+            return items
+
+    m = BatchPredictModel()
+    assert m._predict_mode == PredictMode.BATCH
+
+    class SinglePredictModel(AsyncModel):
+        async def _predict(self, item):
+            return item
+
+    m = SinglePredictModel()
+    assert m._predict_mode == PredictMode.SINGLE
+
+    class BothPredictModel(AsyncModel):
+        async def _predict(self, item):
+            return item
+
+        async def _predict_batch(self, items):
+            return items
+
+    m = SinglePredictModel()
+    with pytest.raises(BothPredictsOverridenError):
+        BothPredictModel()


### PR DESCRIPTION
When one forgets to override one of the methods, nothing happens and we end up with an infinite recursion when `predict` is called. Here we check at init whether one is implemented using a decorator.

It gets slightly tricky to preserve generic typing with the decorator, but other than that it is relatively straightforward.