### PR TITLE
remote store: fail to instantiate assets manager when an assets store…

### DIFF
--- a/modelkit/assets/drivers/s3.py
+++ b/modelkit/assets/drivers/s3.py
@@ -43,6 +43,11 @@ class S3StorageDriver:
             region_name=settings.aws_default_region,
         )
         self.bucket = settings.bucket
+        try:
+            self.client.head_bucket(Bucket=self.bucket)
+        except self.client.exceptions.ClientError:
+            logger.error(f"Bucket {self.bucket} does not exist")
+            raise
 
     @retry(**RETRY_POLICY)
     def iterate_objects(self, prefix=None):

--- a/modelkit/assets/manager.py
+++ b/modelkit/assets/manager.py
@@ -27,8 +27,17 @@ class AssetsManager:
 
         self.remote_assets_store = None
         if settings.remote_store:
-            self.remote_assets_store = RemoteAssetsStore(**settings.remote_store.dict())
-            logger.debug("AssetsManager created with remote storage provider")
+            try:
+                self.remote_assets_store = RemoteAssetsStore(
+                    **settings.remote_store.dict()
+                )
+                logger.debug("AssetsManager created with remote storage provider")
+            except BaseException:
+                # A remote store was parametrized, but it could not be instantiated
+                logger.error(
+                    "Failed to instantiate the requested remote storage provider"
+                )
+                raise
         else:
             logger.debug("AssetsManager created without a remote storage provider")
 

--- a/tests/assets/conftest.py
+++ b/tests/assets/conftest.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import uuid
 
+import boto3
 import pytest
 import requests
 import urllib3
@@ -125,7 +126,6 @@ def _start_s3_manager(working_dir):
             "storage_prefix": f"test-assets-{uuid.uuid1().hex}",
         },
     )
-    mng.remote_assets_store.driver.client.create_bucket(Bucket="test-assets")
     return mng
 
 
@@ -149,6 +149,13 @@ def s3_assetsmanager(request, working_dir):
             "/data",
         ]
     )
+    client = boto3.client(
+        "s3",
+        aws_access_key_id="minioadmin",
+        aws_secret_access_key="minioadmin",
+        endpoint_url="http://127.0.0.1:9000",
+    )
+    client.create_bucket(Bucket="test-assets")
 
     yield _start_s3_manager(working_dir)
 

--- a/tests/assets/test_assetsmanager.py
+++ b/tests/assets/test_assetsmanager.py
@@ -2,9 +2,11 @@ import filecmp
 import os
 import tempfile
 
+import botocore
 import pytest
 
 import modelkit.assets.cli
+from modelkit.assets.manager import AssetsManager
 from tests.conftest import skip_unless
 
 test_path = os.path.dirname(os.path.realpath(__file__))
@@ -135,4 +137,25 @@ def test_download_object_or_prefix_cli(gcs_assetsmanager):
                     "category-test"
                 ),
                 destination_dir=tmp_dir,
+            )
+
+
+@skip_unless("ENABLE_S3_TEST", "True")
+def test_s3_assetsmanager_fail_on_init(s3_assetsmanager):
+    with tempfile.TemporaryDirectory() as tmp_d:
+        with pytest.raises(botocore.exceptions.ClientError):
+            AssetsManager(
+                assets_dir=tmp_d,
+                remote_store={
+                    "driver": {
+                        "storage_provider": "s3",
+                        "aws_default_region": "us-east-1",
+                        "bucket": "DOESNOTEXIST",
+                        "aws_access_key_id": "minioadmin",
+                        "aws_secret_access_key": "minioadmin",
+                        "aws_session_token": None,
+                        "s3_endpoint": "http://127.0.0.1:9000",
+                    },
+                    "storage_prefix": "test-assets-prefix",
+                },
             )


### PR DESCRIPTION
When a remote storage provider is instantiated but fails, this is not exposed to the user. It makes debugging complicated.

In this PR I force checking that the bucket exists (and the parametrized client has rights on it) when the driver is initialized. If it is not it will raise an error after logging.

