### PR TITLE
tensorflow: demote log level when skipping models

### DIFF
--- a/modelkit/utils/tensorflow.py
+++ b/modelkit/utils/tensorflow.py
@@ -32,7 +32,7 @@ def deploy_tf_models(lib, mode, config_name="config", verbose=False):
     for model_name in lib.required_models:
         model_configuration = configuration[model_name]
         if not issubclass(model_configuration.model_type, TensorflowModel):
-            logger.info(f"Skipping non TF model `{model_name}`")
+            logger.debug(f"Skipping non TF model `{model_name}`")
             continue
         if not model_configuration.asset:
             raise ValueError(f"TensorFlow model `{model_name}` does not have an asset")

--- a/tests/assets/conftest.py
+++ b/tests/assets/conftest.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import uuid
 
-import boto3
 import pytest
 import requests
 import urllib3
@@ -126,6 +125,7 @@ def _start_s3_manager(working_dir):
             "storage_prefix": f"test-assets-{uuid.uuid1().hex}",
         },
     )
+    mng.remote_assets_store.driver.client.create_bucket(Bucket="test-assets")
     return mng
 
 
@@ -149,14 +149,6 @@ def s3_assetsmanager(request, working_dir):
             "/data",
         ]
     )
-    client = boto3.client(
-        "s3",
-        aws_access_key_id="minioadmin",
-        aws_secret_access_key="minioadmin",
-        endpoint_url="http://127.0.0.1:9000",
-    )
-    client.create_bucket(Bucket="test-assets")
-
     yield _start_s3_manager(working_dir)
 
     subprocess.call(["docker", "stop", "storage-minio-tests"])


### PR DESCRIPTION
When writing configuration files, we skip a lot of models and at the moment we log with the level info for each of them. That's probably too much 😄 

@pquentin 