### PR TITLE
Model load bug

### DIFF
--- a/modelkit/assets/manager.py
+++ b/modelkit/assets/manager.py
@@ -19,6 +19,10 @@ from modelkit.utils.logging import ContextualizedLogging
 logger = get_logger(__name__)
 
 
+class AssetFetchError(Exception):
+    pass
+
+
 class AssetsManager:
     def __init__(self, **settings):
         if isinstance(settings, dict):
@@ -187,4 +191,15 @@ class AssetsManager:
         with filelock.FileLock(lock_path, timeout=5):
             asset_info = self._fetch_asset(spec, return_info=return_info)
         logger.debug("Fetched asset", spec=spec, asset_info=asset_info)
+        if not os.path.exists(asset_info["path"]):
+            logger.error(
+                "An unknown error occured when fetching asset."
+                "The path does not exist.",
+                asset_info=asset_info,
+                spec=spec,
+            )
+            raise AssetFetchError(
+                f"An unknown error occured when fetching asset {spec}."
+                f"The path {asset_info['path']} does not exist."
+            )
         return asset_info

--- a/modelkit/assets/manager.py
+++ b/modelkit/assets/manager.py
@@ -31,7 +31,10 @@ class AssetsManager:
                 self.remote_assets_store = RemoteAssetsStore(
                     **settings.remote_store.dict()
                 )
-                logger.debug("AssetsManager created with remote storage provider")
+                logger.debug(
+                    "AssetsManager created with remote storage provider",
+                    driver=self.remote_assets_store.driver,
+                )
             except BaseException:
                 # A remote store was parametrized, but it could not be instantiated
                 logger.error(
@@ -50,96 +53,126 @@ class AssetsManager:
             return []
 
     def _fetch_asset(self, spec: AssetSpec, return_info=False):
-        local_name = os.path.join(self.assets_dir, *spec.name.split("/"))
-        local_versions_list = self.get_local_versions_info(local_name)
-        remote_versions_list = []
-        if self.remote_assets_store and (
-            not spec.major_version or not spec.minor_version
-        ):
-            remote_versions_list = self.remote_assets_store.get_versions_info(spec.name)
-        all_versions_list = sort_versions(
-            list({x for x in local_versions_list + remote_versions_list})
-        )
-        if not spec.major_version and not spec.minor_version:
-            # no version is specified
-            if not all_versions_list:
-                # and none exist
-                # in this case, the asset spec is likely a relative or absolute
-                # path to a file/directory
-                if os.path.exists(local_name):
-                    # if the asset spec resolves to MODELKIT_ASSETS_DIR/spec.name
-                    return {"path": local_name}
-                elif os.path.exists(os.path.join(os.getcwd(), *spec.name.split("/"))):
-                    # if the assect spec resolves to cwd/spec.name
-                    return {"path": os.path.join(os.getcwd(), *spec.name.split("/"))}
-                elif os.path.exists(spec.name):
-                    # if the asset spec is a valid absolute path
-                    return {"path": spec.name}
-                else:
-                    raise errors.AssetDoesNotExistError(spec.name)
-
-        if not spec.major_version or not spec.minor_version:
-            if not all_versions_list:
-                raise errors.LocalAssetDoesNotExistError(
-                    name=spec.name,
-                    major=spec.major_version,
-                    minor=spec.minor_version,
-                    local_versions=local_versions_list,
+        with ContextualizedLogging(name=spec.name):
+            local_name = os.path.join(self.assets_dir, *spec.name.split("/"))
+            local_versions_list = self.get_local_versions_info(local_name)
+            logger.debug("Local versions list", local_versions_list=local_versions_list)
+            remote_versions_list = []
+            if self.remote_assets_store and (
+                not spec.major_version or not spec.minor_version
+            ):
+                remote_versions_list = self.remote_assets_store.get_versions_info(
+                    spec.name
                 )
-
-            # at least one version info is missing, fetch the latest
-            if not spec.major_version:
-                spec.major_version, spec.minor_version = parse_version(
-                    all_versions_list[0]
+                logger.debug(
+                    "Fetched remote versions list",
+                    remote_versions_list=remote_versions_list,
                 )
-            elif not spec.minor_version:
-                spec.major_version, spec.minor_version = parse_version(
-                    filter_versions(all_versions_list, major=spec.major_version)[0]
-                )
-            logger.debug(
-                "Resolved latest version",
-                name=spec.name,
-                major=spec.major_version,
-                minor=spec.minor_version,
+            all_versions_list = sort_versions(
+                list({x for x in local_versions_list + remote_versions_list})
             )
+            if not spec.major_version and not spec.minor_version:
+                logger.debug("Asset has no version information")
+                # no version is specified
+                if not all_versions_list:
+                    # and none exist
+                    # in this case, the asset spec is likely a relative or absolute
+                    # path to a file/directory
+                    if os.path.exists(local_name):
+                        logger.debug(
+                            "Asset is a valid local path relative to ASSETS_DIR",
+                            local_name=local_name,
+                        )
+                        # if the asset spec resolves to MODELKIT_ASSETS_DIR/spec.name
+                        return {"path": local_name}
+                    elif os.path.exists(
+                        os.path.join(os.getcwd(), *spec.name.split("/"))
+                    ):
+                        logger.debug(
+                            "Asset is a valid relative local path",
+                            local_name=os.path.exists(
+                                os.path.join(os.getcwd(), *spec.name.split("/"))
+                            ),
+                        )
+                        # if the assect spec resolves to cwd/spec.name
+                        return {
+                            "path": os.path.join(os.getcwd(), *spec.name.split("/"))
+                        }
+                    elif os.path.exists(spec.name):
+                        logger.debug(
+                            "Asset is a valid absolute local path",
+                            local_name=os.path.exists(
+                                os.path.join(os.getcwd(), *spec.name.split("/"))
+                            ),
+                        )
+                        # if the asset spec is a valid absolute path
+                        return {"path": spec.name}
+                    else:
+                        raise errors.AssetDoesNotExistError(spec.name)
 
-        version = f"{spec.major_version}.{spec.minor_version}"
-        with ContextualizedLogging(name=spec.name, version=version):
-            asset_dict = {
-                "from_cache": True,
-                "version": version,
-                "path": os.path.join(self.assets_dir, *spec.name.split("/"), version),
-            }
-            if version not in local_versions_list:
-                if self.remote_assets_store:
-                    logger.info(
-                        "Fetching distant asset",
-                        local_versions=local_versions_list,
-                    )
-                    asset_download_info = self.remote_assets_store.download(
-                        spec.name, version, self.assets_dir
-                    )
-                    asset_dict.update({**asset_download_info, "from_cache": False})
-                else:
+            if not spec.major_version or not spec.minor_version:
+                if not all_versions_list:
                     raise errors.LocalAssetDoesNotExistError(
                         name=spec.name,
                         major=spec.major_version,
                         minor=spec.minor_version,
                         local_versions=local_versions_list,
                     )
-            if spec.sub_part:
-                local_sub_part = os.path.join(
-                    *(
-                        list(os.path.split(str(asset_dict["path"])))
-                        + [p for p in spec.sub_part.split("/") if p]
-                    )
-                )
-                asset_dict["path"] = local_sub_part
 
-        if return_info:
-            return asset_dict
-        else:
-            return asset_dict["path"]
+                # at least one version info is missing, fetch the latest
+                if not spec.major_version:
+                    spec.major_version, spec.minor_version = parse_version(
+                        all_versions_list[0]
+                    )
+                elif not spec.minor_version:
+                    spec.major_version, spec.minor_version = parse_version(
+                        filter_versions(all_versions_list, major=spec.major_version)[0]
+                    )
+                logger.debug(
+                    "Resolved latest version",
+                    major=spec.major_version,
+                    minor=spec.minor_version,
+                )
+
+            version = f"{spec.major_version}.{spec.minor_version}"
+            with ContextualizedLogging(version=version):
+                asset_dict = {
+                    "from_cache": True,
+                    "version": version,
+                    "path": os.path.join(
+                        self.assets_dir, *spec.name.split("/"), version
+                    ),
+                }
+                if version not in local_versions_list:
+                    if self.remote_assets_store:
+                        logger.info(
+                            "Fetching distant asset",
+                            local_versions=local_versions_list,
+                        )
+                        asset_download_info = self.remote_assets_store.download(
+                            spec.name, version, self.assets_dir
+                        )
+                        asset_dict.update({**asset_download_info, "from_cache": False})
+                    else:
+                        raise errors.LocalAssetDoesNotExistError(
+                            name=spec.name,
+                            major=spec.major_version,
+                            minor=spec.minor_version,
+                            local_versions=local_versions_list,
+                        )
+                if spec.sub_part:
+                    local_sub_part = os.path.join(
+                        *(
+                            list(os.path.split(str(asset_dict["path"])))
+                            + [p for p in spec.sub_part.split("/") if p]
+                        )
+                    )
+                    asset_dict["path"] = local_sub_part
+
+            if return_info:
+                return asset_dict
+            else:
+                return asset_dict["path"]
 
     def fetch_asset(self, spec: Union[AssetSpec, str], return_info=False):
         logger.info("Fetching asset", spec=spec, return_info=return_info)
@@ -152,4 +185,6 @@ class AssetsManager:
         )
         os.makedirs(os.path.dirname(lock_path), exist_ok=True)
         with filelock.FileLock(lock_path, timeout=5):
-            return self._fetch_asset(spec, return_info=return_info)
+            asset_info = self._fetch_asset(spec, return_info=return_info)
+        logger.debug("Fetched asset", spec=spec, asset_info=asset_info)
+        return asset_info

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -246,7 +246,9 @@ class ModelLibrary:
         This function loads dependent models for the current models, populating
         the _models dictionary with the instantiated model objects.
         """
+        logger.debug("Loading model", model_name=model_name)
         if model_name in self.models:
+            logger.debug("Model already loaded", model_name=model_name)
             return
 
         configuration = self.configuration[model_name]
@@ -263,6 +265,7 @@ class ModelLibrary:
             **self.required_models.get(model_name, {}),
         }
 
+        logger.debug("Instantiating Model object", model_name=model_name)
         self.models[model_name] = configuration.model_type(
             asset_path=self.assets_info[configuration.asset].path
             if configuration.asset
@@ -273,13 +276,15 @@ class ModelLibrary:
             configuration_key=model_name,
             cache=self.cache,
         )
+        logger.debug("Done loading Model", model_name=model_name)
 
-    def _resolve_assets(self, configuration_key):
+    def _resolve_assets(self, model_name):
         """
         This function fetches assets for the current model and its dependent models
         and populates the assets_info dictionary with the paths.
         """
-        configuration = self.configuration[configuration_key]
+        logger.debug("Resolving asset for Model", model_name=model_name)
+        configuration = self.configuration[model_name]
         # First, resolve assets from dependent models
         for dep_name in configuration.model_dependencies.values():
             self._resolve_assets(dep_name)
@@ -290,14 +295,18 @@ class ModelLibrary:
 
         model_settings = {
             **configuration.model_settings,
-            **self.required_models.get(configuration_key, {}),
+            **self.required_models.get(model_name, {}),
         }
 
         # If the asset is overriden in the model_settings
         if "asset_path" in model_settings:
-            self.assets_info[configuration.asset] = AssetInfo(
-                path=model_settings.pop("asset_path")
+            asset_path = model_settings.pop("asset_path")
+            logger.debug(
+                "Overriding asset from Model settings",
+                model_name=model_name,
+                asset_path=asset_path,
             )
+            self.assets_info[configuration.asset] = AssetInfo(path=asset_path)
 
         asset_spec = AssetSpec.from_string(configuration.asset)
 
@@ -307,8 +316,8 @@ class ModelLibrary:
         )
         local_file = os.environ.get(venv)
         if local_file:
-            logger.info(
-                "Overriding asset from env variable",
+            logger.debug(
+                "Overriding asset from environment variable",
                 asset_name=asset_spec.name,
                 path=local_file,
             )
@@ -321,6 +330,11 @@ class ModelLibrary:
         )
         version = os.environ.get(venv)
         if version:
+            logger.debug(
+                "Overriding asset version from environment variable",
+                asset_name=asset_spec.name,
+                path=local_file,
+            )
             asset_spec = AssetSpec.from_string(asset_spec.name + ":" + version)
 
         if self.override_assets_manager:
@@ -333,7 +347,7 @@ class ModelLibrary:
                         return_info=True,
                     )
                 )
-                logger.info(
+                logger.debug(
                     "Asset has been loaded with overriden prefix",
                     name=asset_spec.name,
                 )

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -323,8 +323,8 @@ class ModelLibrary:
         if version:
             asset_spec = AssetSpec.from_string(asset_spec.name + ":" + version)
 
-        try:
-            if self.override_assets_manager:
+        if self.override_assets_manager:
+            try:
                 self.assets_info[configuration.asset] = AssetInfo(
                     **self.override_assets_manager.fetch_asset(
                         spec=AssetSpec(
@@ -337,11 +337,12 @@ class ModelLibrary:
                     "Asset has been loaded with overriden prefix",
                     name=asset_spec.name,
                 )
-        except modelkit.assets.errors.ObjectDoesNotExistError:
-            logger.debug(
-                "Asset not found in overriden prefix",
-                name=asset_spec.name,
-            )
+            except modelkit.assets.errors.ObjectDoesNotExistError:
+                logger.debug(
+                    "Asset not found in overriden prefix",
+                    name=asset_spec.name,
+                )
+
         if configuration.asset not in self.assets_info:
             self.assets_info[configuration.asset] = AssetInfo(
                 **self.asset_manager.fetch_asset(asset_spec, return_info=True)

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -246,6 +246,9 @@ class ModelLibrary:
         This function loads dependent models for the current models, populating
         the _models dictionary with the instantiated model objects.
         """
+        if model_name in self.models:
+            return
+
         configuration = self.configuration[model_name]
 
         # First, load dependent predictors and add them to the model
@@ -270,8 +273,6 @@ class ModelLibrary:
             configuration_key=model_name,
             cache=self.cache,
         )
-        if not self.settings.lazy_loading:
-            self.models[model_name].load()
 
     def _resolve_assets(self, configuration_key):
         """

--- a/tests/assets/test_assetsmanager.py
+++ b/tests/assets/test_assetsmanager.py
@@ -2,11 +2,9 @@ import filecmp
 import os
 import tempfile
 
-import botocore
 import pytest
 
 import modelkit.assets.cli
-from modelkit.assets.manager import AssetsManager
 from tests.conftest import skip_unless
 
 test_path = os.path.dirname(os.path.realpath(__file__))

--- a/tests/assets/test_local_manager.py
+++ b/tests/assets/test_local_manager.py
@@ -87,7 +87,7 @@ def test_local_manager_with_versions(working_dir):
         assert res["path"] == os.path.abspath(os.path.join(local_dir, ".."))
 
         abs_path_to_readme = os.path.join(os.path.abspath(local_dir), "README.md")
-        res = manager.fetch_asset(abs_path_to_readme)
+        res = manager.fetch_asset(abs_path_to_readme, return_info=True)
         assert res["path"] == abs_path_to_readme
     finally:
         shutil.rmtree("tmp-local-asset")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-from json import load
 
 import pytest
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -514,3 +514,34 @@ def test_model_multiple_load():
     lib.get("b")
     lib.get("a")
     assert loaded == 1
+
+
+def test_model_multiple_asset_load(working_dir, monkeypatch):
+    monkeypatch.setenv("MODELKIT_ASSETS_DIR", working_dir)
+    with open(os.path.join(working_dir, "something.txt"), "w") as f:
+        f.write("OK")
+
+    class SomeModel(Model):
+        CONFIGURATIONS = {"a": {"asset": "something.txt"}}
+
+        def _predict(self, item):
+            return item
+
+    class SomeModel2(Model):
+        CONFIGURATIONS = {"b": {"asset": "something.txt"}}
+
+        def _predict(self, item):
+            return item
+
+    fetched = 0
+
+    def fake_fetch_asset(asset_spec, return_info=True):
+        nonlocal fetched
+        fetched += 1
+        return {"path": os.path.join(working_dir, "something.txt")}
+
+    lib = ModelLibrary(models=[SomeModel, SomeModel2], settings={"lazy_loading": True})
+    monkeypatch.setattr(lib.asset_manager, "fetch_asset", fake_fetch_asset)
+    lib.preload()
+
+    assert fetched == 1


### PR DESCRIPTION
When re-reading the model loading logic, I noticed that we do not check that models are already loaded, which can result in a given model being loaded multiple times 😨 . I am not sure when we lost this, but it definitely needs to make it back in there.

I add a test to check for this behavior, and another one to check that the same is true for assets (which did not exhibit a bug though).

Finally, I add many log messages in the AssetsManager as well as in the ModelLibrary, and demote some log messages to `debug` in order to have a much clearer view of the assets resolution process when debugging. These won't appear unless we have `LOG_LEVEL=debug`

NB: changes may look big, but they are not, it's just that the contextualized logging makes us gain an indentation level