### PR TITLE
Fix settings auto env

### DIFF
--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -17,7 +17,9 @@ logger = get_logger(__name__)
 
 
 class DriverSettings(BaseSettings):
-    storage_provider: str
+    storage_provider: str = pydantic.Field(
+        None, env="MODELKIT_STORAGE_PROVIDER"
+    )
     settings: Optional[Union[GCSDriverSettings, S3DriverSettings, LocalDriverSettings]]
 
     @root_validator(pre=True)
@@ -25,11 +27,7 @@ class DriverSettings(BaseSettings):
     def dispatch_settings(cls, fields):
         if "settings" in fields:
             return fields
-        storage_provider = fields.pop("storage_provider", None) or os.getenv(
-            "MODELKIT_STORAGE_PROVIDER", None
-        )
-        if not storage_provider:
-            return {"storage_provider": None, "settings": None}
+        storage_provider = fields.pop("storage_provider", None)
         if storage_provider not in SUPPORTED_MODELKIT_STORAGE_PROVIDERS:
             logger.error(
                 f"Unknown storage provider `{storage_provider}`, "

--- a/tests/assets/test_assetsmanager.py
+++ b/tests/assets/test_assetsmanager.py
@@ -2,11 +2,9 @@ import filecmp
 import os
 import tempfile
 
-import botocore
 import pytest
 
 import modelkit.assets.cli
-from modelkit.assets.manager import AssetsManager
 from tests.conftest import skip_unless
 
 test_path = os.path.dirname(os.path.realpath(__file__))

--- a/tests/assets/test_settings.py
+++ b/tests/assets/test_settings.py
@@ -183,3 +183,14 @@ def test_assetsmanager_default():
     settings = AssetsManagerSettings()
     assert settings.assets_dir == Path(os.getcwd())
     assert settings.remote_store is None
+
+
+def test_assetsmanager_storage_provider_bug(monkeypatch):
+    monkeypatch.setenv("STORAGE_PROVIDER", "gcs")
+    monkeypatch.setenv("MODELKIT_STORAGE_PROVIDER", "s3")
+    monkeypatch.setenv("MODELKIT_STORAGE_BUCKET", "some-bucket")
+    settings = DriverSettings()
+    assert settings.storage_provider == "s3"
+
+    settings = AssetsManagerSettings()
+    assert settings.remote_store.driver.storage_provider == "s3"


### PR DESCRIPTION
Here I fix the bug in which pydantic reads STORAGE_PROVIDER although it shouldn't. Its the default behavior for BaseSettings