### PR TITLE
assetsmanager: make the lock timeout parametrizable 

### DIFF
--- a/docs/assets/environment.md
+++ b/docs/assets/environment.md
@@ -18,7 +18,8 @@ The parameters necessary to instantiate an `AssetsManager` can all be read from 
 | `MODELKIT_STORAGE_PROVIDER` | `gcs` | `storage_provider` | `gcs` (default), `s3` or `local` |
 | `MODELKIT_STORAGE_BUCKET` | None | `bucket` | Bucket in which data is stored |
 | `MODELKIT_STORAGE_PREFIX` | `modelkit-assets` | `storage_prefix` | Objects prefix |
-| `MODELKIT_STORAGE_TIMEOUT_S` | `300` | `timeout_s` | file lock timeout when downloading assets |
+| `MODELKIT_STORAGE_TIMEOUT_S` | `300` | `timeout_s` | max time when retrying storage downloads |
+| `MODELKIT_ASSETS_TIMEOUT_S` | `10` | `timeout` | file lock timeout when downloading assets |
 
 More settings can be passed in order to configure the driver itself.
 

--- a/modelkit/assets/manager.py
+++ b/modelkit/assets/manager.py
@@ -28,6 +28,7 @@ class AssetsManager:
         if isinstance(settings, dict):
             settings = AssetsManagerSettings(**settings)
         self.assets_dir = settings.assets_dir
+        self.timeout = settings.timeout
 
         self.remote_assets_store = None
         if settings.remote_store:
@@ -185,7 +186,7 @@ class AssetsManager:
             os.path.join(self.assets_dir, ".cache", *spec.name.split("/")) + ".lock"
         )
         os.makedirs(os.path.dirname(lock_path), exist_ok=True)
-        with filelock.FileLock(lock_path, timeout=5):
+        with filelock.FileLock(lock_path, timeout=self.timeout):
             asset_info = self._fetch_asset(spec)
         logger.debug("Fetched asset", spec=spec, asset_info=asset_info)
         path = asset_info["path"]

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -17,9 +17,7 @@ logger = get_logger(__name__)
 
 
 class DriverSettings(BaseSettings):
-    storage_provider: str = pydantic.Field(
-        None, env="MODELKIT_STORAGE_PROVIDER"
-    )
+    storage_provider: str = pydantic.Field(None, env="MODELKIT_STORAGE_PROVIDER")
     settings: Optional[Union[GCSDriverSettings, S3DriverSettings, LocalDriverSettings]]
 
     @root_validator(pre=True)
@@ -70,6 +68,7 @@ class AssetsManagerSettings(BaseSettings):
     assets_dir: pydantic.DirectoryPath = pydantic.Field(
         default_factory=lambda: os.getcwd(), env="MODELKIT_ASSETS_DIR"
     )
+    timeout: int = pydantic.Field(5, env="MODELKIT_ASSETS_TIMEOUT_S")
 
     @root_validator(pre=True)
     @classmethod

--- a/modelkit/assets/settings.py
+++ b/modelkit/assets/settings.py
@@ -68,7 +68,7 @@ class AssetsManagerSettings(BaseSettings):
     assets_dir: pydantic.DirectoryPath = pydantic.Field(
         default_factory=lambda: os.getcwd(), env="MODELKIT_ASSETS_DIR"
     )
-    timeout: int = pydantic.Field(5, env="MODELKIT_ASSETS_TIMEOUT_S")
+    timeout: int = pydantic.Field(10, env="MODELKIT_ASSETS_TIMEOUT_S")
 
     @root_validator(pre=True)
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def assetsmanager_settings(working_dir):
 def clean_env():
     for env_var in [
         "MODELKIT_ASSETS_DIR",
+        "MODELKIT_ASSETS_TIMEOUT_S",
         "MODELKIT_CACHE_HOST",
         "MODELKIT_CACHE_IMPLEMENTATION",
         "MODELKIT_CACHE_MAX_SIZE",


### PR DESCRIPTION
Sometimes the timeout of 5s on acquiring the lock to download assets is not enough. In this PR I bump it to 10s and make it parametrizable via `MODELKIT_ASSETS_TIMEOUT_S`.