### PR TITLE
docs: add coverage html report

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   docs:
@@ -25,3 +29,23 @@ jobs:
         run: mkdocs gh-deploy --force
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Download Coverage Report
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: main.yml
+          name: coverage
+          path: coverage
+
+      - name: Push Coverage Report
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add coverage
+          git commit -m "add coverage report"
+          git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,11 @@ jobs:
           git add docs/badges
           git diff-index --quiet HEAD || git commit -m "generate badges"
           git push
+
+      - name: 'Upload coverage report'
+        if: ${{matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' && github.ref == 'refs/heads/main'}}
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: docs/coverage
+          retention-days: 1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <img src="https://img.shields.io/github/workflow/status/clustree/modelkit/CI/main" />
   <img src="docs/badges/tests.svg" />
-  <img src="docs/badges/coverage.svg" />
+  <a href="https://clustree.github.io/modelkit/coverage"><img src="docs/badges/coverage.svg" /></a>
   <img src="https://img.shields.io/pypi/v/modelkit" />
   <img src="https://img.shields.io/pypi/pyversions/modelkit" />
   <a href="https://clustree.github.io/modelkit/index.html"><img src="https://img.shields.io/badge/docs-latest-blue" /></a>

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,6 +17,7 @@ def coverage(session):
     session.run("coverage", "run", "-m", "pytest", "--junitxml=junit.xml")
     session.run("coverage", "report", "-m")
     session.run("coverage", "xml")
+    session.run("coverage", "html", "-d", "docs/coverage")
 
     # Generate README badges using genbadge, junit.xml and coverage.xml
     session.install("genbadge[coverage,tests]")


### PR DESCRIPTION
In this PR, I add the coverage report to the github page leveraging the artifact management system:
1) [main workflow] generate the html coverage report
2) [main workflow] upload it to artefacts
3) [docs workflow] download the just uploaded coverage report artefact
4) [docs workflow] deploy github pages, then add the coverage report & push

The coverage report will only be generated & pushed on main 
