### PR TITLE
API testing + fix asyncmodel bug

### DIFF
--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -95,34 +95,29 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
             description += "\n\n```" + str(capture.get()) + "```"
 
             logger.info("Adding model", name=model_name)
+            item_type = m._item_type or Any
             try:
-                item_type = m._item_type or Any
-                try:
-                    item_type.schema()  # type: ignore
-                except (ValueError, AttributeError):
-                    item_type = Any
+                item_type.schema()  # type: ignore
+            except (ValueError, AttributeError):
+                item_type = Any
 
-                self.add_api_route(
-                    path,
-                    self._make_model_endpoint_fn(m, item_type),
-                    methods=["POST"],
-                    description=description,
-                    summary=summary,
-                    tags=[str(type(m).__module__)],
-                )
-                self.add_api_route(
-                    batch_path,
-                    self._make_batch_model_endpoint_fn(m, item_type),
-                    methods=["POST"],
-                    description=description,
-                    summary=summary,
-                    tags=[str(type(m).__module__)],
-                )
-                logger.info("Added model to service", name=model_name, path=path)
-            except fastapi.exceptions.FastAPIError as exc:
-                logger.error(
-                    "Could not add model to service", name=model_name, path=exc
-                )
+            self.add_api_route(
+                path,
+                self._make_model_endpoint_fn(m, item_type),
+                methods=["POST"],
+                description=description,
+                summary=summary,
+                tags=[str(type(m).__module__)],
+            )
+            self.add_api_route(
+                batch_path,
+                self._make_batch_model_endpoint_fn(m, item_type),
+                methods=["POST"],
+                description=description,
+                summary=summary,
+                tags=[str(type(m).__module__)],
+            )
+            logger.info("Added model to service", name=model_name, path=path)
 
     def _make_model_endpoint_fn(self, model, item_type):
         if isinstance(model, AsyncModel):

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -147,7 +147,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
         if isinstance(model, AsyncModel):
 
             async def _aendpoint(
-                item: item_type = fastapi.Body(...),
+                item: List[item_type] = fastapi.Body(...),
                 model=fastapi.Depends(lambda: self.lib.get(model.configuration_key)),
             ):  # noqa: B008
                 return await model.predict_batch(item)

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -104,7 +104,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
                 self.add_api_route(
                     path,
-                    self._make_model_endpoint_fn(model_name, item_type),
+                    self._make_model_endpoint_fn(m, item_type),
                     methods=["POST"],
                     description=description,
                     summary=summary,
@@ -112,7 +112,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
                 )
                 self.add_api_route(
                     batch_path,
-                    self._make_batch_model_endpoint_fn(model_name, item_type),
+                    self._make_batch_model_endpoint_fn(m, item_type),
                     methods=["POST"],
                     description=description,
                     summary=summary,
@@ -124,12 +124,12 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
                     "Could not add model to service", name=model_name, path=exc
                 )
 
-    def _make_model_endpoint_fn(self, model_name, item_type):
-        if isinstance(model_name, AsyncModel):
+    def _make_model_endpoint_fn(self, model, item_type):
+        if isinstance(model, AsyncModel):
 
             async def _aendpoint(
                 item: item_type = fastapi.Body(...),
-                model=fastapi.Depends(lambda: self.lib.get(model_name)),
+                model=fastapi.Depends(lambda: self.lib.get(model.configuration_key)),
             ):  # noqa: B008
                 return await model.predict(item)
 
@@ -137,18 +137,18 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
         def _endpoint(
             item: item_type = fastapi.Body(...),
-            model=fastapi.Depends(lambda: self.lib.get(model_name)),
+            model=fastapi.Depends(lambda: self.lib.get(model.configuration_key)),
         ):  # noqa: B008
             return model.predict(item)
 
         return _endpoint
 
-    def _make_batch_model_endpoint_fn(self, model_name, item_type):
-        if isinstance(model_name, AsyncModel):
+    def _make_batch_model_endpoint_fn(self, model, item_type):
+        if isinstance(model, AsyncModel):
 
             async def _aendpoint(
                 item: item_type = fastapi.Body(...),
-                model=fastapi.Depends(lambda: self.lib.get(model_name)),
+                model=fastapi.Depends(lambda: self.lib.get(model.configuration_key)),
             ):  # noqa: B008
                 return await model.predict_batch(item)
 
@@ -156,7 +156,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
 
         def _endpoint(
             item: List[item_type] = fastapi.Body(...),
-            model=fastapi.Depends(lambda: self.lib.get(model_name)),
+            model=fastapi.Depends(lambda: self.lib.get(model.configuration_key)),
         ):  # noqa: B008
             return model.predict_batch(item)
 

--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -99,6 +99,9 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
             try:
                 item_type.schema()  # type: ignore
             except (ValueError, AttributeError):
+                logger.info(
+                    "Discarding item type info for model", name=model_name, path=path
+                )
                 item_type = Any
 
             self.add_api_route(

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -167,7 +167,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
                 t
                 for t in self.__orig_bases__
                 if isinstance(t, typing._GenericAlias)
-                and issubclass(t.__origin__, Model)
+                and issubclass(t.__origin__, AbstractModel)
             ]
             if len(generic_aliases):
                 _item_type, _return_type = generic_aliases[0].__args__

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -216,5 +216,3 @@ def test_create_modelkit_app(
         monkeypatch.setenv("MODELKIT_REQUIRED_MODELS", required_models_env_var)
     app = create_modelkit_app(models=models, required_models=required_models)
     assert len([route.path for route in app.routes]) == n_endpoints
-    # import ipdb
-    # ipdb.set_trace()

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -166,8 +166,8 @@ async def _do_model_test_async(model, ITEMS):
     res = await model.predict_batch(ITEMS)
     assert res == ITEMS
 
-    res = await model.predict_batch(ITEMS + [{"new": "item"}])
-    assert ITEMS + [{"new": "item"}] == res
+    res = await model.predict_batch(ITEMS + [{"ok": {"boomer": [-1]}}])
+    assert ITEMS + [{"ok": {"boomer": [-1]}}] == res
 
 
 @pytest.mark.asyncio

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,7 +4,7 @@ import pydantic
 import pytest
 
 from modelkit.core.errors import ItemValidationException, ReturnValueValidationException
-from modelkit.core.model import Model
+from modelkit.core.model import AsyncModel, Model
 from modelkit.core.settings import LibrarySettings
 from modelkit.utils.pydantic import construct_recursive
 
@@ -39,6 +39,41 @@ def test_validate_item_spec_pydantic(service_settings):
         m({"x": "something", "blabli": 10})
 
     assert m.predict_batch([valid_test_item] * 2) == [valid_test_item] * 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_settings",
+    [
+        LibrarySettings(),
+        LibrarySettings(enable_validation=False),
+    ],
+)
+async def test_validate_item_spec_pydantic_async(service_settings):
+    class ItemModel(pydantic.BaseModel):
+        x: int
+
+    class AsyncSomeValidatedModel(AsyncModel[ItemModel, Any]):
+        async def _predict(self, item):
+            return item
+
+    valid_test_item = {"x": 10}
+
+    m = AsyncSomeValidatedModel(service_settings=service_settings)
+    res = await m(valid_test_item)
+    assert res == valid_test_item
+
+    if service_settings.enable_validation:
+        with pytest.raises(ItemValidationException):
+            await m({"ok": 1})
+        with pytest.raises(ItemValidationException):
+            await m({"x": "something", "blabli": 10})
+    else:
+        await m({"ok": 1})
+        await m({"x": "something", "blabli": 10})
+
+    res_list = await m.predict_batch([valid_test_item] * 2)
+    assert res_list == [valid_test_item] * 2
 
 
 @pytest.mark.parametrize(

--- a/tests/testdata/api/openapi.json
+++ b/tests/testdata/api/openapi.json
@@ -63,13 +63,13 @@
   "paths": {
     "/predict/async_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n```",
-        "operationId": "_endpoint_predict_async_model_post",
+        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n├── signature: ItemModel -> ItemModel                                           \n```",
+        "operationId": "_aendpoint_predict_async_model_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "title": "Item"
+                "$ref": "#/components/schemas/ItemModel"
               }
             }
           },
@@ -95,7 +95,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": " Endpoint",
+        "summary": " Aendpoint",
         "tags": [
           "tests.test_api"
         ]
@@ -103,13 +103,15 @@
     },
     "/predict/batch/async_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n```",
-        "operationId": "_endpoint_predict_batch_async_model_post",
+        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n├── signature: ItemModel -> ItemModel                                           \n```",
+        "operationId": "_aendpoint_predict_batch_async_model_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "items": {},
+                "items": {
+                  "$ref": "#/components/schemas/ItemModel"
+                },
                 "title": "Item",
                 "type": "array"
               }
@@ -137,7 +139,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": " Endpoint",
+        "summary": " Aendpoint",
         "tags": [
           "tests.test_api"
         ]
@@ -187,7 +189,7 @@
     },
     "/predict/batch/some_complex_model": {
       "post": {
-        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n```",
+        "description": "    With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│       With **a lot** of documentation                                         \n├── signature: ItemModel -> ItemModel                                           \n```",
         "operationId": "_endpoint_predict_batch_some_complex_model_post",
         "requestBody": {
           "content": {
@@ -231,7 +233,7 @@
     },
     "/predict/batch/some_model": {
       "post": {
-        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n```",
+        "description": "    that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│       that also has plenty more text                                          \n├── signature: str -> str                                                       \n```",
         "operationId": "_endpoint_predict_batch_some_model_post",
         "requestBody": {
           "content": {
@@ -355,7 +357,7 @@
     },
     "/predict/some_complex_model": {
       "post": {
-        "description": "        With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│           With **a lot** of documentation                                     \n├── signature: ItemModel -> ItemModel                                           \n```",
+        "description": "    With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│       With **a lot** of documentation                                         \n├── signature: ItemModel -> ItemModel                                           \n```",
         "operationId": "_endpoint_predict_some_complex_model_post",
         "requestBody": {
           "content": {
@@ -395,7 +397,7 @@
     },
     "/predict/some_model": {
       "post": {
-        "description": "        that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│           that also has plenty more text                                      \n├── signature: str -> str                                                       \n```",
+        "description": "    that also has plenty more text\n\n```                                                                                \n├── configuration: some_model                                                   \n├── doc: This is a summary                                                      \n│                                                                               \n│       that also has plenty more text                                          \n├── signature: str -> str                                                       \n```",
         "operationId": "_endpoint_predict_some_model_post",
         "requestBody": {
           "content": {


### PR DESCRIPTION
In modelkit.api two things we not tested:
- async model endpoint generation
- create_modelkit_app

In this PR I add tests for both, which bumps the coverage to 100% in this module

Adding a test for async models made me realize that inputs were not correctly validated in `AsyncModel` classes because types could not be retrieved correctly (there was an explicit check that the types derived from a subclass of `Model` 🙄 )