### PR TITLE
Fix lint CI

### DIFF
--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -165,8 +165,8 @@ def create_modelkit_app(models=None, required_models=None):
     """
     Creates a modelkit FastAPI app with the specified models and required models.
 
-    This is meant to be used in conjunction with gunicorn or uvicorn in order to 
-    start a server.
+    This is meant to be used in conjunction with gunicorn or uvicorn in order to
+     start a server.
 
     Run with:
     ```

--- a/modelkit/cli.py
+++ b/modelkit/cli.py
@@ -5,7 +5,6 @@ import sys
 from time import perf_counter, sleep
 
 import click
-import fastapi
 import humanize
 import networkx as nx
 import uvicorn
@@ -17,7 +16,7 @@ from rich.table import Table
 from rich.tree import Tree
 
 from modelkit import ModelLibrary
-from modelkit.api import ModelkitAutoAPIRouter, create_modelkit_app
+from modelkit.api import create_modelkit_app
 from modelkit.assets.cli import assets_cli
 from modelkit.core.model_configuration import configure, list_assets
 from modelkit.utils.serialization import safe_np_dump

--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -25,7 +25,6 @@ import humanize
 import pydantic
 import redis
 from asgiref.sync import AsyncToSync
-from pydantic import ValidationError
 from rich.console import Console
 from rich.tree import Tree
 from structlog import get_logger

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 black modelkit tests bin --check
 isort modelkit tests bin --check-only


### PR DESCRIPTION
Linting in the CI did not fail if one of the commands failed (here, flake8). Adding `set -e` makes the whole script fail if a command fails.

I let the lint after the first commit run to expose the issue, then I remove the problematic lines and make the PR