### PR TITLE
create_modelkit_app: set models default to None

### DIFF
--- a/modelkit/api.py
+++ b/modelkit/api.py
@@ -162,7 +162,7 @@ class ModelkitAutoAPIRouter(ModelkitAPIRouter):
         return _endpoint
 
 
-def create_modelkit_app(models, required_models=None):
+def create_modelkit_app(models=None, required_models=None):
     """
     Creates a modelkit FastAPI app with the specified models and required models.
 


### PR DESCRIPTION
so that to use:
```
gunicorn ... 'modelkit.api:create_modelkit_app()'
```
instead of the ugly:
```
gunicorn ... 'modelkit.api:create_modelkit_app(None)'
```