### PR TITLE
Batching with multiprocessing CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,22 @@ modelkit dependencies-graph [PACKAGE] [--required-models ...]
 This requires [graphviz](https://graphviz.org/) for the graph layout. 
 
 
+## Predictions
+
+### batch
+
+This CLI will treat a given JSONL file, with one item per line and write the output of a 
+model as another JSONL file, using multiple processes for speed
+
+```sh
+modelkit batch MODEL_NAME DATA_IN DATA_OUT [--models PACKAGE] [--processes N_PROCESSES] [--unordered]
+```
+
+Where:
+- `--models` to tell it where to find the model
+- `--processes` allows you to define the number of processes (defaults to all CPUs)
+- `--unordered` does not preserve the order of outputs (as with `imap_unordered`), which may be faster
+
 ## Benchmarking
 
 ### Memory benchmark

--- a/modelkit/cli.py
+++ b/modelkit/cli.py
@@ -20,7 +20,6 @@ from modelkit.assets.cli import assets_cli
 from modelkit.core.errors import ModelsNotFound
 from modelkit.core.library import download_assets
 from modelkit.core.model_configuration import list_assets
-from modelkit.utils.logging import ContextualizedLogging
 from modelkit.utils.serialization import safe_np_dump
 
 
@@ -349,7 +348,7 @@ def reader(input, queues):
 @click.option("--unordered", is_flag=True)
 def batch_predict(model_name, input, output, models, processes, unordered):
     """
-    Make predictions for a given model.
+    Barch predictions for a given model.
     """
     processes = processes or os.cpu_count()
     print(f"Using {processes} processes")

--- a/modelkit/cli.py
+++ b/modelkit/cli.py
@@ -304,7 +304,6 @@ def writer(output, q, n_workers):
             while len(items_to_write) and items_to_write[0][0] == next_index:
                 _, res = items_to_write.pop(0)
                 f.write(json.dumps(res) + "\n")
-                f.flush()
                 next_index += 1
     return next_index
 
@@ -322,7 +321,6 @@ def writer_unordered(output, q, n_workers):
                 continue
             _, res = m
             f.write(json.dumps(res) + "\n")
-            f.flush()
             n_items += 1
 
     return n_items

--- a/modelkit/cli.py
+++ b/modelkit/cli.py
@@ -265,7 +265,7 @@ def worker(model, q_in, q):
             break
         item = json.loads(m.strip())
         res = model.predict(item)
-        q.put(res)
+        q.put(json.dumps(res) + "\n")
         n += 1
     q.put(None)
     return n
@@ -277,7 +277,7 @@ def writer(output, q):
             m = q.get()
             if m is None:
                 break
-            f.write(json.dumps(m) + "\n")
+            f.write(m)
             f.flush()
 
 


### PR DESCRIPTION
In this PR I add a CLI that allows reading from a JSONL file, create a number of separate processes to process the data with a `modelkit.Model` and output it to JSONL too.

Some features:
- one process reads, and another one writes data
- lazy loads the models, such that non serializable models work
- it also builds batches for each worker
- it supports ordered and unordered output
