### PR TITLE
cli: fix serve using lists or None

### DIFF
--- a/modelkit/cli.py
+++ b/modelkit/cli.py
@@ -238,7 +238,9 @@ def serve(models, required_models, host, port):
 
     Run an HTTP server with specified models using FastAPI
     """
-    app = create_modelkit_app(models=models, required_models=required_models)
+    app = create_modelkit_app(
+        models=list(models) or None, required_models=list(required_models) or None
+    )
     uvicorn.run(app, host=host, port=port)
 
 


### PR DESCRIPTION
Currently, two bugs occur when it comes to serving using modelkit and uvicorn:
- using `modelkit serve` does not use the `MODELKIT_DEFAULT_PACKAGE` env variable since a tuple is passed, not None
- using `modelkit serve -r your_model` does not work, since a tuple is passed, not a list (due to a `isinstance(x, list)`)

Indeed, `create_modelkit_app` and `ModelLibrary` expect lists or None values to proceed, not tuples.
